### PR TITLE
make use of physics configurable

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
@@ -39,6 +39,9 @@ public class Settings
         this.disabledGameModes = new HashSet<>(addon.getConfig().getStringList("disabled-gamemodes"));
         this.offlineGeneration = addon.getConfig().getBoolean("offline-generation");
 
+        // if physics should be used
+        this.physics = addon.getConfig().getBoolean("use-physics", false);
+
         // Reads Generator Tiers
         if (addon.getConfig().isSet("tiers"))
         {
@@ -142,6 +145,15 @@ public class Settings
         return this.customGeneratorTierMap.getOrDefault(addon, Collections.emptyMap());
     }
 
+    /**
+     * This method returns if physics should be used when placing a block
+     * .
+     * @return usePhysics
+     */
+    public boolean usePhysics()
+    {
+        return physics;
+    }
 
     // ---------------------------------------------------------------------
     // Section: Private object
@@ -287,4 +299,9 @@ public class Settings
      * Set that contains all disabled game modes.
      */
     private Set<String> disabledGameModes;
+
+    /**
+     * Boolean to indicate if physics should be used when placing a block
+     */
+    private boolean physics;
 }

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGenerator.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGenerator.java
@@ -67,8 +67,8 @@ public class MagicGenerator
             double rand = random.nextDouble() * chanceMap.lastKey();
             newMaterial = chanceMap.ceilingEntry(rand).getValue();
         }
-        // Don't use physics
-        block.setType(newMaterial, false);
+        // ask config if physics should be used
+        block.setType(newMaterial, addon.getSettings().usePhysics());
         return true;
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,11 @@ disabled-gamemodes: []
 # Disables custom generation if all island members are offline
 offline-generation: false
 
+# If physics should be used when placing a block. 
+# using physics allow certain redstone machanics to work, 
+# but might have unwanted side effects
+use-physics: false
+
 # Default Tiers
 # Each tier must contain:
 #      min-level: island level (integer) | -1 will mean that this level will be the only level that will be applied. | First level will be always selected


### PR DESCRIPTION
This will make the use of physics (when placing a block) configurable. 
Might be useful, since some redstone machines won't work without, see #33. 