### PR TITLE
Allow Stone generators to be magical

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/listeners/MainGeneratorListener.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/listeners/MainGeneratorListener.java
@@ -78,10 +78,10 @@ public class MainGeneratorListener implements Listener {
         if (!this.isInRangeToGenerate(eventSourceBlock)) {
             return;
         }
-        // Run 1-tick later to catch the type made and only take action on cobblestone, not obsidian
+        // Run 1-tick later to catch the type made and only take action on cobblestone or stone, not obsidian
         Bukkit.getScheduler().runTask(addon.getPlugin(), () -> {
-            // Lava is generating cobblestone into eventToBlock place
-            if (eventSourceBlock.getType().equals(Material.COBBLESTONE) && this.addon.getGenerator().isReplacementGenerated(eventSourceBlock, true)) {
+            // Lava is generating cobblestone or stone into eventToBlock place
+            if ((eventSourceBlock.getType().equals(Material.COBBLESTONE) || eventSourceBlock.getType().equals(Material.STONE)) && this.addon.getGenerator().isReplacementGenerated(eventSourceBlock, true)) {
                 // sound when lava transforms to cobble
                 this.playEffects(eventSourceBlock);
             }


### PR DESCRIPTION
Allows stone generators to generate from the chance map via the Block Form Event instead of only generating stone. (only matters if Block From To Event is removed).