### PR TITLE
Fixes an issue with incorrect message reporting

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
@@ -233,7 +233,7 @@ public class GeneratorAdminCommand extends CompositeCommand
             // Set meta data on player
             Island island = this.getAddon().getIslands().getIsland(this.getWorld(), targetUUID);
 
-            if (island == null || island.getOwner() == null)
+            if (island == null || island.getOwner() == null || !island.getOwner().equals(targetUUID))
             {
                 Utils.sendMessage(user,
                     user.getTranslation("general.errors.player-is-not-owner"));


### PR DESCRIPTION
In the Discord was a complaint that `why` command reported that for non-owners they receive `offline-player` message instead of `player-is-not-owner`. 

This happened because I missed adding a check for comparing if the island owner is the targetUUID.