### PR TITLE
Only register IslandLevelListener if Level addon is present

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/StoneGeneratorAddon.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/StoneGeneratorAddon.java
@@ -122,7 +122,8 @@ public class StoneGeneratorAddon extends Addon
         //this.registerListener(new MagicGeneratorListener(this));
 
         this.registerListener(new JoinLeaveListener(this));
-        this.registerListener(new IslandLevelListener(this));
+        if(this.getAddonByName("Level").isPresent())
+            this.registerListener(new IslandLevelListener(this));
 
         // Register Flags
         this.registerFlag(MAGIC_COBBLESTONE_GENERATOR);


### PR DESCRIPTION
Fix for 

[19:01:07] [Server thread/ERROR]: [BentoBox] Failed to register events for class world.bentobox.magiccobblestonegenerator.listeners.IslandLevelListener because world/bentobox/level/events/IslandLevelCalculatedEvent does not exist.