### PR TITLE
Add cancellable GeneratorTreasureDropEvent for treasure drops (#140)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEvent.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEvent.java
@@ -1,0 +1,253 @@
+//
+// Created by BONNe
+// Copyright - 2020
+//
+
+
+package world.bentobox.magiccobblestonegenerator.events;
+
+
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+import world.bentobox.bentobox.api.events.BentoBoxEvent;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+
+
+/**
+ * This event is fired just before a generator drops a treasure item at the generated block location. It is cancellable
+ * and the dropped {@link ItemStack} can be modified, so other plugins can intercept, change or veto treasure drops.
+ * <p>
+ * The magic generator produces blocks from a {@code BlockFormEvent} (lava/water flow) rather than from a player mining a
+ * block, so there is no player or broken block state associated with the drop. This dedicated event is therefore used
+ * instead of Bukkit's {@code BlockDropItemEvent}, which requires both.
+ */
+public class GeneratorTreasureDropEvent extends BentoBoxEvent implements Cancellable
+{
+    /**
+     * Instantiates a new Generator treasure drop event.
+     *
+     * @param generator the generator tier that produced the treasure
+     * @param islandUUID the island unique id, or null if unknown
+     * @param location the location where the treasure will be dropped
+     * @param itemStack the treasure item that will be dropped
+     */
+    public GeneratorTreasureDropEvent(GeneratorTierObject generator,
+        String islandUUID,
+        Location location,
+        ItemStack itemStack)
+    {
+        this.generator = generator.getFriendlyName();
+        this.generatorID = generator.getUniqueId();
+
+        this.islandUUID = islandUUID;
+        this.location = location;
+        this.itemStack = itemStack;
+    }
+
+
+    /**
+     * Gets island uuid.
+     *
+     * @return the island uuid, or null if unknown
+     */
+    public String getIslandUUID()
+    {
+        return islandUUID;
+    }
+
+
+    /**
+     * Sets island uuid.
+     *
+     * @param islandUUID the island uuid
+     */
+    public void setIslandUUID(String islandUUID)
+    {
+        this.islandUUID = islandUUID;
+    }
+
+
+    /**
+     * Gets generator.
+     *
+     * @return the generator
+     */
+    public String getGenerator()
+    {
+        return generator;
+    }
+
+
+    /**
+     * Sets generator.
+     *
+     * @param generator the generator
+     */
+    public void setGenerator(String generator)
+    {
+        this.generator = generator;
+    }
+
+
+    /**
+     * Gets generator id.
+     *
+     * @return the generator id
+     */
+    public String getGeneratorID()
+    {
+        return generatorID;
+    }
+
+
+    /**
+     * Sets generator id.
+     *
+     * @param generatorID the generator id
+     */
+    public void setGeneratorID(String generatorID)
+    {
+        this.generatorID = generatorID;
+    }
+
+
+    /**
+     * Gets the location where the treasure will be dropped.
+     *
+     * @return the location
+     */
+    public Location getLocation()
+    {
+        return location;
+    }
+
+
+    /**
+     * Sets the location where the treasure will be dropped.
+     *
+     * @param location the location
+     */
+    public void setLocation(Location location)
+    {
+        this.location = location;
+    }
+
+
+    /**
+     * Gets the treasure item that will be dropped.
+     *
+     * @return the item stack
+     */
+    public ItemStack getItemStack()
+    {
+        return itemStack;
+    }
+
+
+    /**
+     * Sets the treasure item that will be dropped. Allows listeners to change the treasure.
+     *
+     * @param itemStack the item stack
+     */
+    public void setItemStack(ItemStack itemStack)
+    {
+        this.itemStack = itemStack;
+    }
+
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not be executed in the server, but will still
+     * pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    @Override
+    public boolean isCancelled()
+    {
+        return this.cancelled;
+    }
+
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not drop the treasure, but will still pass to
+     * other plugins.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    @Override
+    public void setCancelled(boolean cancel)
+    {
+        this.cancelled = cancel;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Handler methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Gets handlers.
+     *
+     * @return the handlers
+     */
+    @Override
+    public HandlerList getHandlers()
+    {
+        return GeneratorTreasureDropEvent.handlers;
+    }
+
+
+    /**
+     * Gets handlers.
+     *
+     * @return the handlers
+     */
+    public static HandlerList getHandlerList()
+    {
+        return GeneratorTreasureDropEvent.handlers;
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+    /**
+     * Island Id.
+     */
+    private String islandUUID;
+
+    /**
+     * Friendly name for generator.
+     */
+    private String generator;
+
+    /**
+     * Generator ID.
+     */
+    private String generatorID;
+
+    /**
+     * Location where the treasure will be dropped.
+     */
+    private Location location;
+
+    /**
+     * The treasure item that will be dropped.
+     */
+    private ItemStack itemStack;
+
+    /**
+     * Boolean that indicates if event is cancelled.
+     */
+    private boolean cancelled;
+
+    /**
+     * Event listener list for current
+     */
+    private static final HandlerList handlers = new HandlerList();
+}

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEvent.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEvent.java
@@ -12,7 +12,6 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
-import world.bentobox.bentobox.api.events.BentoBoxEvent;
 import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
 
 
@@ -24,7 +23,7 @@ import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierOb
  * block, so there is no player or broken block state associated with the drop. This dedicated event is therefore used
  * instead of Bukkit's {@code BlockDropItemEvent}, which requires both.
  */
-public class GeneratorTreasureDropEvent extends BentoBoxEvent implements Cancellable
+public class GeneratorTreasureDropEvent extends GeneratorEvent implements Cancellable
 {
     /**
      * Instantiates a new Generator treasure drop event.
@@ -39,78 +38,10 @@ public class GeneratorTreasureDropEvent extends BentoBoxEvent implements Cancell
         Location location,
         ItemStack itemStack)
     {
-        this.generator = generator.getFriendlyName();
-        this.generatorID = generator.getUniqueId();
-
-        this.islandUUID = islandUUID;
+        // Treasure drops originate from block formation, so there is no associated player.
+        super(generator, null, islandUUID);
         this.location = location;
         this.itemStack = itemStack;
-    }
-
-
-    /**
-     * Gets island uuid.
-     *
-     * @return the island uuid, or null if unknown
-     */
-    public String getIslandUUID()
-    {
-        return islandUUID;
-    }
-
-
-    /**
-     * Sets island uuid.
-     *
-     * @param islandUUID the island uuid
-     */
-    public void setIslandUUID(String islandUUID)
-    {
-        this.islandUUID = islandUUID;
-    }
-
-
-    /**
-     * Gets generator.
-     *
-     * @return the generator
-     */
-    public String getGenerator()
-    {
-        return generator;
-    }
-
-
-    /**
-     * Sets generator.
-     *
-     * @param generator the generator
-     */
-    public void setGenerator(String generator)
-    {
-        this.generator = generator;
-    }
-
-
-    /**
-     * Gets generator id.
-     *
-     * @return the generator id
-     */
-    public String getGeneratorID()
-    {
-        return generatorID;
-    }
-
-
-    /**
-     * Sets generator id.
-     *
-     * @param generatorID the generator id
-     */
-    public void setGeneratorID(String generatorID)
-    {
-        this.generatorID = generatorID;
     }
 
 
@@ -215,21 +146,6 @@ public class GeneratorTreasureDropEvent extends BentoBoxEvent implements Cancell
 // ---------------------------------------------------------------------
 // Section: Variables
 // ---------------------------------------------------------------------
-
-    /**
-     * Island Id.
-     */
-    private String islandUUID;
-
-    /**
-     * Friendly name for generator.
-     */
-    private String generator;
-
-    /**
-     * Generator ID.
-     */
-    private String generatorID;
 
     /**
      * Location where the treasure will be dropped.

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/listeners/GeneratorListener.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/listeners/GeneratorListener.java
@@ -170,7 +170,7 @@ public abstract class GeneratorListener implements Listener
             return null;
         }
 
-        return this.addon.getGenerator().processBlockReplacement(generatorTier, location);
+        return this.addon.getGenerator().processBlockReplacement(generatorTier, location, island);
     }
 
 
@@ -194,7 +194,7 @@ public abstract class GeneratorListener implements Listener
             return null;
         }
 
-        return this.addon.getGenerator().processBlockReplacement(generatorTier, location);
+        return this.addon.getGenerator().processBlockReplacement(generatorTier, location, island);
     }
 
 
@@ -218,7 +218,7 @@ public abstract class GeneratorListener implements Listener
             return null;
         }
 
-        return this.addon.getGenerator().processBlockReplacement(generatorTier, location);
+        return this.addon.getGenerator().processBlockReplacement(generatorTier, location, island);
     }
 
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGenerator.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGenerator.java
@@ -4,13 +4,16 @@ package world.bentobox.magiccobblestonegenerator.tasks;
 import java.util.Random;
 import java.util.TreeMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
+import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon;
 import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+import world.bentobox.magiccobblestonegenerator.events.GeneratorTreasureDropEvent;
 import world.bentobox.magiccobblestonegenerator.utils.Why;
 
 
@@ -38,6 +41,22 @@ public class MagicGenerator
      * @return the replaced material or null.
      */
     public @Nullable Material processBlockReplacement(@Nullable GeneratorTierObject generatorTier, Location location)
+    {
+        return this.processBlockReplacement(generatorTier, location, null);
+    }
+
+
+    /**
+     * This method tries to replace block from chance map and returns if it was successful.
+     *
+     * @param generatorTier Object that contains all possible chances.
+     * @param location Location of the block that need to be replaced.
+     * @param island Island on which the block is processed, or null if unknown. Used to provide context for the
+     *     {@link GeneratorTreasureDropEvent}.
+     * @return the replaced material or null.
+     */
+    public @Nullable Material processBlockReplacement(@Nullable GeneratorTierObject generatorTier, Location location,
+        @Nullable Island island)
     {
         if (generatorTier == null)
         {
@@ -121,10 +140,27 @@ public class MagicGenerator
                     ItemStack drop = itemStack.clone();
                     drop.setAmount(this.random.nextInt(generatorTier.getMaxTreasureAmount() + 1) + 1);
 
-                    Why.report(location, "Dropping treasure " + drop + " by " + generatorTier.getUniqueId());
+                    // Fire a cancellable event so other plugins can intercept, modify or veto the treasure drop.
+                    GeneratorTreasureDropEvent treasureEvent = new GeneratorTreasureDropEvent(generatorTier,
+                        island == null ? null : island.getUniqueId(),
+                        location,
+                        drop);
+                    Bukkit.getPluginManager().callEvent(treasureEvent);
 
-                    // drop item naturally in the location of the block
-                    location.getWorld().dropItemNaturally(location, drop);
+                    if (!treasureEvent.isCancelled() && treasureEvent.getItemStack() != null)
+                    {
+                        ItemStack finalDrop = treasureEvent.getItemStack();
+                        Location dropLocation = treasureEvent.getLocation();
+
+                        Why.report(location, "Dropping treasure " + finalDrop + " by " + generatorTier.getUniqueId());
+
+                        // drop item naturally in the location of the block
+                        dropLocation.getWorld().dropItemNaturally(dropLocation, finalDrop);
+                    }
+                    else
+                    {
+                        Why.report(location, "Treasure drop cancelled by " + generatorTier.getUniqueId());
+                    }
                 }
             }
         }

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEventTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/events/GeneratorTreasureDropEventTest.java
@@ -1,0 +1,88 @@
+package world.bentobox.magiccobblestonegenerator.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.Location;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+
+/**
+ * Tests for {@link GeneratorTreasureDropEvent}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GeneratorTreasureDropEventTest {
+
+    @Mock
+    private GeneratorTierObject generatorTier;
+    @Mock
+    private Location location;
+    @Mock
+    private ItemStack itemStack;
+
+    private GeneratorTreasureDropEvent event;
+
+    @BeforeEach
+    void setUp() {
+        when(generatorTier.getFriendlyName()).thenReturn("Basic Tier");
+        when(generatorTier.getUniqueId()).thenReturn("basic_tier");
+        event = new GeneratorTreasureDropEvent(generatorTier, "island-1", location, itemStack);
+    }
+
+    @Test
+    void testEventPopulatesFieldsFromArguments() {
+        assertEquals("Basic Tier", event.getGenerator());
+        assertEquals("basic_tier", event.getGeneratorID());
+        assertEquals("island-1", event.getIslandUUID());
+        assertSame(location, event.getLocation());
+        assertSame(itemStack, event.getItemStack());
+    }
+
+    @Test
+    void testEventIsNotCancelledByDefault() {
+        assertFalse(event.isCancelled());
+    }
+
+    @Test
+    void testSetCancelled() {
+        event.setCancelled(true);
+        assertTrue(event.isCancelled());
+    }
+
+    @Test
+    void testSetItemStackAllowsModification() {
+        ItemStack other = mock(ItemStack.class);
+        event.setItemStack(other);
+        assertSame(other, event.getItemStack());
+    }
+
+    @Test
+    void testSetters() {
+        Location newLocation = mock(Location.class);
+        event.setIslandUUID("island-2");
+        event.setGenerator("Other");
+        event.setGeneratorID("other");
+        event.setLocation(newLocation);
+        assertEquals("island-2", event.getIslandUUID());
+        assertEquals("Other", event.getGenerator());
+        assertEquals("other", event.getGeneratorID());
+        assertSame(newLocation, event.getLocation());
+    }
+
+    @Test
+    void testHandlers() {
+        assertNotNull(event.getHandlers());
+        assertNotNull(GeneratorTreasureDropEvent.getHandlerList());
+    }
+}

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGeneratorTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/tasks/MagicGeneratorTest.java
@@ -1,0 +1,115 @@
+package world.bentobox.magiccobblestonegenerator.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.TreeMap;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import world.bentobox.magiccobblestonegenerator.CommonTestSetup;
+import world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+import world.bentobox.magiccobblestonegenerator.events.GeneratorTreasureDropEvent;
+
+/**
+ * Tests for {@link MagicGenerator}, focused on the treasure drop event (#140).
+ */
+class MagicGeneratorTest extends CommonTestSetup {
+
+    @Mock
+    private StoneGeneratorAddon addon;
+    @Mock
+    private GeneratorTierObject generatorTier;
+    @Mock
+    private ItemStack treasure;
+
+    private MagicGenerator generator;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Block chance map with a single guaranteed material.
+        TreeMap<Double, Material> blockMap = new TreeMap<>();
+        blockMap.put(1.0, Material.COBBLESTONE);
+        when(generatorTier.getBlockChanceMap()).thenReturn(blockMap);
+        when(generatorTier.getMinHeight()).thenReturn(-64);
+        when(generatorTier.getMaxHeight()).thenReturn(320);
+        when(generatorTier.getMaterialHeightRange(any())).thenReturn(null);
+        when(generatorTier.getUniqueId()).thenReturn("basic_tier");
+        when(generatorTier.getFriendlyName()).thenReturn("Basic Tier");
+
+        // Guaranteed treasure drop.
+        TreeMap<Double, ItemStack> treasureMap = new TreeMap<>();
+        treasureMap.put(1.0, treasure);
+        when(treasure.clone()).thenReturn(treasure);
+        when(generatorTier.getMaxTreasureAmount()).thenReturn(1);
+        when(generatorTier.getTreasureChance()).thenReturn(1.0);
+        when(generatorTier.getTreasureItemChanceMap()).thenReturn(treasureMap);
+
+        // Location returns the mocked world.
+        when(location.getWorld()).thenReturn(world);
+
+        generator = new MagicGenerator(addon);
+    }
+
+    @Test
+    void testProcessBlockReplacementReturnsMaterial() {
+        Material result = generator.processBlockReplacement(generatorTier, location, island);
+        assertEquals(Material.COBBLESTONE, result);
+    }
+
+    @Test
+    void testTreasureDropFiresEventAndDrops() {
+        generator.processBlockReplacement(generatorTier, location, island);
+        verify(pim).callEvent(any(GeneratorTreasureDropEvent.class));
+        verify(world).dropItemNaturally(location, treasure);
+    }
+
+    @Test
+    void testCancelledTreasureDropEventPreventsDrop() {
+        Mockito.doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof GeneratorTreasureDropEvent drop) {
+                drop.setCancelled(true);
+            }
+            return null;
+        }).when(pim).callEvent(any(GeneratorTreasureDropEvent.class));
+
+        Material result = generator.processBlockReplacement(generatorTier, location, island);
+
+        // Block is still generated, but no treasure is dropped.
+        assertEquals(Material.COBBLESTONE, result);
+        verify(world, never()).dropItemNaturally(any(Location.class), any(ItemStack.class));
+    }
+
+    @Test
+    void testListenerReplacesTreasureItem() {
+        ItemStack replacement = mock(ItemStack.class);
+        Mockito.doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof GeneratorTreasureDropEvent drop) {
+                drop.setItemStack(replacement);
+            }
+            return null;
+        }).when(pim).callEvent(any(GeneratorTreasureDropEvent.class));
+
+        generator.processBlockReplacement(generatorTier, location, island);
+
+        // The modified item is the one that gets dropped.
+        verify(world).dropItemNaturally(location, replacement);
+        verify(world, never()).dropItemNaturally(location, treasure);
+    }
+}


### PR DESCRIPTION
Closes #140

## Problem
There is currently no way for other plugins to intercept, modify or veto the treasure items a generator drops.

## Why not `BlockDropItemEvent`?
The issue suggested `BlockDropItemEvent`. However, generators produce blocks from a `BlockFormEvent` (lava/water flow), **not** from a player mining a block. `BlockDropItemEvent` requires a non-null `Player` and a broken `BlockState`, neither of which exists in the generation path (`processBlockReplacement` has only the generator tier, location and island). Firing it with a fabricated player during block *formation* would mislead other listeners.

As the reporter noted, "a custom event would be an option as well." This PR takes that route with a dedicated, purpose-built event.

## Change
Adds a cancellable `GeneratorTreasureDropEvent`, fired in `MagicGenerator` immediately before the treasure is dropped. Listeners can:
- **cancel** it to veto the drop, or
- **replace the `ItemStack`** (and/or drop `Location`) to modify what drops.

The event carries the generator tier (id + friendly name), island UUID, drop location and the item. A backwards-compatible `processBlockReplacement(tier, location, island)` overload threads the island through for context; the existing two-arg method delegates with a `null` island, so no external callers break.

```java
@EventHandler
public void onTreasure(GeneratorTreasureDropEvent e) {
    if (blockedWorld(e.getLocation())) e.setCancelled(true);
    else e.setItemStack(remap(e.getItemStack()));
}
```

## Tests
- `GeneratorTreasureDropEventTest` — field population, cancellable contract, item/location setters, handlers.
- `MagicGeneratorTest` — event is fired and item drops; cancelling prevents the drop (block still generates); replacing the `ItemStack` drops the replacement.

All 10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)