### PR TITLE
Revoke permission-gated generators when island owner loses permission (#133)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -871,6 +871,47 @@ public class StoneGeneratorManager {
 		.
 		// Now process each generator.
 		forEach(generator -> this.unlockGenerator(dataObject, user, island, generator));
+
+	// Revoke permission based generators that the current owner no longer qualifies for.
+	// This handles ownership transfer to a player without the required permission (#133).
+	this.revokePermissionGenerators(island, dataObject, owner);
+    }
+
+    /**
+     * This method revokes access to permission based generators that the current island owner no longer holds the
+     * required permissions for. Only the unlocked and active status is revoked; any purchase record is preserved so the
+     * generator becomes available again if the permission is regained.
+     * <p>
+     * Permissions can only be checked reliably for an online owner, so nothing is revoked while the owner is offline.
+     *
+     * @param island     Island which is targeted for the check.
+     * @param dataObject Data object that stores island generators.
+     * @param owner      The island owner, or null (e.g. spawn islands).
+     */
+    private void revokePermissionGenerators(@NotNull Island island, @NotNull GeneratorDataObject dataObject,
+	    @Nullable User owner) {
+	if (owner == null || !owner.isOnline()) {
+	    // Cannot reliably check permissions of an offline owner. Do not revoke anything.
+	    return;
+	}
+
+	List<GeneratorTierObject> revokeList = this.getIslandGeneratorTiers(island.getWorld(), dataObject).stream()
+		// Only permission gated generators can be revoked this way.
+		.filter(generator -> !generator.getRequiredPermissions().isEmpty())
+		// That are currently unlocked.
+		.filter(generator -> dataObject.getUnlockedTiers().contains(generator.getUniqueId()))
+		// But whose required permissions the current owner does not have.
+		.filter(generator -> !Utils.matchAllPermissions(owner, generator.getRequiredPermissions()))
+		.collect(Collectors.toList());
+
+	if (!revokeList.isEmpty()) {
+	    revokeList.forEach(generator -> {
+		dataObject.getUnlockedTiers().remove(generator.getUniqueId());
+		dataObject.getActiveGeneratorList().remove(generator.getUniqueId());
+	    });
+
+	    this.saveGeneratorData(dataObject);
+	}
     }
 
     /**

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -326,6 +326,69 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
         verify(island, times(2)).isSpawn();
     }
 
+    /**
+     * Seeds a deployed, permission-gated generator tier into the cache and returns the freshly created island data with
+     * that tier already unlocked and active, simulating a generator that a previous owner had unlocked.
+     */
+    private GeneratorDataObject seedPermissionGeneratorAndData() {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-133");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+
+        when(generatorTier.getUniqueId()).thenReturn("magiccobblegenerator_perm");
+        when(generatorTier.isDeployed()).thenReturn(true);
+        when(generatorTier.isDefaultGenerator()).thenReturn(false);
+        when(generatorTier.getGeneratorType()).thenReturn(GeneratorType.COBBLESTONE);
+        when(generatorTier.getRequiredMinIslandLevel()).thenReturn(0L);
+        when(generatorTier.getRequiredPermissions())
+                .thenReturn(java.util.Set.of("magiccobblegenerator.gen.perm"));
+        sgm.loadGeneratorTier(generatorTier, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+        data.getUnlockedTiers().add("magiccobblegenerator_perm");
+        data.getActiveGeneratorList().add("magiccobblegenerator_perm");
+        return data;
+    }
+
+    @Test
+    void testCheckGeneratorUnlockStatusRevokesPermissionGeneratorWhenOwnerLacksPermission() {
+        GeneratorDataObject data = seedPermissionGeneratorAndData();
+        // Owner is online but does not have the required permission (new owner scenario, #133).
+        when(mockPlayer.isOnline()).thenReturn(true);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_perm"));
+        assertFalse(data.getActiveGeneratorList().contains("magiccobblegenerator_perm"));
+    }
+
+    @Test
+    void testCheckGeneratorUnlockStatusKeepsPermissionGeneratorWhenOwnerHasPermission() {
+        GeneratorDataObject data = seedPermissionGeneratorAndData();
+        when(mockPlayer.isOnline()).thenReturn(true);
+        // Owner still has the required permission.
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_perm"));
+        assertTrue(data.getActiveGeneratorList().contains("magiccobblegenerator_perm"));
+    }
+
+    @Test
+    void testCheckGeneratorUnlockStatusDoesNotRevokeWhenOwnerOffline() {
+        GeneratorDataObject data = seedPermissionGeneratorAndData();
+        // Owner is offline, so permissions cannot be checked reliably and nothing is revoked.
+        when(mockPlayer.isOnline()).thenReturn(false);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_perm"));
+        assertTrue(data.getActiveGeneratorList().contains("magiccobblegenerator_perm"));
+    }
+
     @Test
     void testGetGeneratorDataIsland() {
         assertNotNull(sgm.getGeneratorData(island));


### PR DESCRIPTION
Closes #133

## Bug
Unlocked generator tiers were a **permanent** grant, never revoked when an island's owner changed. Reproduction from the issue:

1. Player A (who has permission for `gen.A`) creates an island → `gen.A` is unlocked and stored in the island's `unlockedTiers`.
2. Player A leaves and hands ownership to Player B, who does **not** have that permission.
3. `gen.A` is still unlocked and can be activated on the island.

`checkGeneratorUnlockStatus(...)` only ever *added* to `unlockedTiers`; nothing removed a tier when the owner/permission changed.

## Fix
`checkGeneratorUnlockStatus` now also **revokes** permission-gated tiers from the island's `unlockedTiers` and active-generator list when the current owner does not hold the required permissions.

This piggybacks on the existing `TeamSetownerEvent → validateIslandData → checkGeneratorUnlockStatus` path (see `JoinLeaveListener`), so it triggers on ownership transfer, as well as on island-level checks.

### Design choices
- **Purchase records are preserved.** Only *access* (unlocked + active) is revoked, not `purchasedTiers`, so a generator that was paid for becomes available again if the permission is regained. While not unlocked, it still can't be activated (the activation path already checks `unlockedTiers`).
- **Offline owners are left untouched.** Permissions can't be checked reliably for an offline player, so revocation only happens when the owner is online — mirroring the existing unlock logic, which also only grants permission-based unlocks while online. This avoids thrashing.
- Only tiers that actually declare required permissions are considered.

## Tests
Added to `StoneGeneratorManagerTest`:
- `...RevokesPermissionGeneratorWhenOwnerLacksPermission` — the reported bug: online owner without the permission → tier revoked from unlocked + active.
- `...KeepsPermissionGeneratorWhenOwnerHasPermission` — owner still has it → kept.
- `...DoesNotRevokeWhenOwnerOffline` — offline owner → kept (conservative).

All 54 tests in `StoneGeneratorManagerTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)