### PR TITLE
Stable generator ordering by unique id (#123)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -502,11 +502,13 @@ public class StoneGeneratorManager {
 	// Filter generators that starts with name.
 		filter(generator -> generator.getUniqueId().startsWith(gameMode.toLowerCase())).
 		// Sort in order: default generators are first, followed by lowest priority,
-		// generator type and then by generator name.
+		// generator type and then by the stable unique id.
 		sorted(Comparator.comparing(GeneratorTierObject::isDefaultGenerator).reversed()
 			.thenComparing(GeneratorTierObject::getPriority)
 			.thenComparing(GeneratorTierObject::getGeneratorType)
-			.thenComparing(GeneratorTierObject::getFriendlyName))
+			// Final tiebreaker is the stable unique id, not the friendly name, so that
+			// renaming a generator does not change its position in the list (#123).
+			.thenComparing(GeneratorTierObject::getUniqueId))
 		.
 		// Return as list collection.
 		collect(Collectors.toList());

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/BundleEditPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/BundleEditPanel.java
@@ -162,7 +162,8 @@ public class BundleEditPanel extends CommonPagedPanel<GeneratorTierObject>
             sorted(Comparator.comparing(GeneratorTierObject::isDefaultGenerator).reversed().
                 thenComparing(GeneratorTierObject::getPriority).
                 thenComparing(GeneratorTierObject::getGeneratorType).
-                thenComparing(GeneratorTierObject::getFriendlyName)).
+                // Stable tiebreaker so renaming does not reorder generators (#123).
+                thenComparing(GeneratorTierObject::getUniqueId)).
             collect(Collectors.toList());
 
         if (this.mode == Mode.ADD)

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -273,6 +273,45 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
         assertTrue(sgm.getAllGeneratorTiers(world).isEmpty());
     }
 
+    /**
+     * Builds a deployed, non-default cobblestone generator tier mock for ordering tests.
+     */
+    private GeneratorTierObject orderableTier(String id, String name, int priority) {
+        GeneratorTierObject t = mock(GeneratorTierObject.class);
+        when(t.getUniqueId()).thenReturn(id);
+        when(t.getFriendlyName()).thenReturn(name);
+        when(t.getPriority()).thenReturn(priority);
+        when(t.getGeneratorType()).thenReturn(GeneratorType.COBBLESTONE);
+        when(t.isDeployed()).thenReturn(true);
+        when(t.isDefaultGenerator()).thenReturn(false);
+        return t;
+    }
+
+    @Test
+    void testGetAllGeneratorTiersEqualPrioritySortsByUniqueIdNotName() {
+        sgm.addWorld(world);
+        // Same priority + type. Names are reverse of id order to prove the tiebreaker is the id.
+        GeneratorTierObject a = orderableTier("magiccobblegenerator_aaa", "Zebra", 10);
+        GeneratorTierObject b = orderableTier("magiccobblegenerator_zzz", "Apple", 10);
+        sgm.loadGeneratorTier(b, true, null);
+        sgm.loadGeneratorTier(a, true, null);
+
+        // Ordered by unique id (aaa before zzz), independent of the friendly names.
+        assertEquals(java.util.List.of(a, b), sgm.getAllGeneratorTiers(world));
+    }
+
+    @Test
+    void testGetAllGeneratorTiersSortsByPriority() {
+        sgm.addWorld(world);
+        GeneratorTierObject low = orderableTier("magiccobblegenerator_x", "X", 5);
+        GeneratorTierObject high = orderableTier("magiccobblegenerator_a", "A", 20);
+        sgm.loadGeneratorTier(high, true, null);
+        sgm.loadGeneratorTier(low, true, null);
+
+        // Lower priority number comes first, regardless of unique id or name.
+        assertEquals(java.util.List.of(low, high), sgm.getAllGeneratorTiers(world));
+    }
+
     @Test
     void testGetIslandGeneratorTiersWorldUser() {
         assertTrue(sgm.getIslandGeneratorTiers(world, user).isEmpty());


### PR DESCRIPTION
Closes #123

## Context
The request was for a way to explicitly order generators in the player GUI (e.g. numbers 10/20/30/40). That capability **already exists**: the per-generator `priority` field (added in 2.0.0) is admin-editable in the generator edit panel, and the player list is sorted by it (`getAllGeneratorTiers`: default → priority → type → name).

The one part of the report that wasn't addressed: the final tiebreaker was the **friendly name**, so renaming a generator moved its position — "it starts showing up right next to the default one instead of staying in the spot it was."

## Change
Replace the `friendlyName` final tiebreaker with the **stable `uniqueId`** in the two places generators are sorted:
- `StoneGeneratorManager.getAllGeneratorTiers` (drives the player list and most panels)
- `BundleEditPanel`

Now, within an equal priority + type, order is stable and independent of renaming. Admins control ordering via `priority` as before.

## Tests
Added to `StoneGeneratorManagerTest`:
- `...EqualPrioritySortsByUniqueIdNotName` — two tiers, same priority, names in reverse of id order → sorted by id, proving names no longer affect order.
- `...SortsByPriority` — lower priority number comes first regardless of id/name.

All 53 tests in `StoneGeneratorManagerTest` pass.

> Note: `priority` already provided the display-number ordering the issue asked for; this PR just makes ties stable. If preferred, the issue could instead be closed as already-supported — happy to do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)