### PR TITLE
Add optional purchase confirmation before buying a generator (#109)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
@@ -307,6 +307,28 @@ public class Settings implements ConfigObject
 
 
     /**
+     * Is buy confirmation boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isBuyConfirmation()
+    {
+        return buyConfirmation;
+    }
+
+
+    /**
+     * Sets buy confirmation.
+     *
+     * @param buyConfirmation the buy confirmation
+     */
+    public void setBuyConfirmation(boolean buyConfirmation)
+    {
+        this.buyConfirmation = buyConfirmation;
+    }
+
+
+    /**
      * Is use bank account boolean.
      *
      * @return the boolean
@@ -485,6 +507,12 @@ public class Settings implements ConfigObject
     @ConfigComment("Useful for situations with one active generator, which will be changed upon activating next one.")
     @ConfigEntry(path = "overwrite-on-activate")
     private boolean overwriteOnActive = false;
+
+    @ConfigComment("")
+    @ConfigComment("Ask the player to confirm before buying a generator, to avoid accidental purchases.")
+    @ConfigComment("The confirmation is requested via a chat prompt.")
+    @ConfigEntry(path = "buy-confirmation")
+    private boolean buyConfirmation = true;
 
     @ConfigComment("")
     @ConfigComment("Send a notification message when player unlocks a new generator.")

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
@@ -24,6 +24,8 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon;
 import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorBundleObject;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorDataObject;
 import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
 import world.bentobox.magiccobblestonegenerator.managers.StoneGeneratorManager;
 import world.bentobox.magiccobblestonegenerator.utils.Constants;
@@ -121,6 +123,55 @@ public abstract class CommonPanel
     public final void reopen()
     {
         this.build();
+    }
+
+
+    /**
+     * This method purchases the given generator for the user, optionally asking for confirmation first.
+     * <p>
+     * If the generator cannot be purchased, the relevant message is sent by
+     * {@link StoneGeneratorManager#canPurchaseGenerator} and the panel is simply rebuilt. When the
+     * {@code buy-confirmation} setting is enabled, a chat confirmation is requested before the purchase is made, to
+     * avoid accidental purchases (#109).
+     *
+     * @param island        Island on which the generator is purchased.
+     * @param generatorData Data that stores island generators.
+     * @param generatorTier Generator tier that should be purchased.
+     */
+    protected void purchaseGenerator(Island island, GeneratorDataObject generatorData, GeneratorTierObject generatorTier)
+    {
+        if (island == null || !this.manager.canPurchaseGenerator(this.user, island, generatorData, generatorTier))
+        {
+            // Cannot purchase. canPurchaseGenerator already sent the reason. Just refresh the panel.
+            this.build();
+            return;
+        }
+
+        if (!this.addon.getSettings().isBuyConfirmation())
+        {
+            // Confirmation disabled. Purchase directly.
+            this.manager.purchaseGenerator(this.user, island, generatorData, generatorTier);
+            this.build();
+            return;
+        }
+
+        // Ask the player to confirm the purchase.
+        ConversationUtils.createConfirmation(
+            confirm ->
+            {
+                if (confirm)
+                {
+                    this.manager.purchaseGenerator(this.user, island, generatorData, generatorTier);
+                }
+
+                // Rebuild the panel regardless of the answer.
+                this.build();
+            },
+            this.user,
+            this.user.getTranslation(Constants.CONVERSATIONS + "confirm-generator-purchase",
+                Constants.GENERATOR, generatorTier.getFriendlyName(),
+                TextVariables.NUMBER, this.hundredThousandsFormat.format(generatorTier.getGeneratorTierCost())),
+            null);
     }
 
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/player/GeneratorUserPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/player/GeneratorUserPanel.java
@@ -604,15 +604,7 @@ public class GeneratorUserPanel extends CommonPanel
                         case "VIEW" -> {
                             GeneratorViewPanel.openPanel(this, generatorTier);
                         }
-                        case "BUY" -> {
-                            if (this.island != null && this.manager.canPurchaseGenerator(user, this.island, this.generatorData, generatorTier))
-                            {
-                                this.manager.purchaseGenerator(this.user, this.island, this.generatorData, generatorTier);
-                            }
-
-                            // Build whole gui.
-                            this.build();
-                        }
+                        case "BUY" -> this.purchaseGenerator(this.island, this.generatorData, generatorTier);
                         case "ACTIVATE" -> {
                             if (this.island != null && this.manager.canActivateGenerator(user, this.island, this.generatorData, generatorTier))
                             {

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/player/GeneratorViewPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/player/GeneratorViewPanel.java
@@ -800,15 +800,7 @@ public class GeneratorViewPanel extends CommonPanel
                         case "VIEW" -> {
                             GeneratorViewPanel.openPanel(this, this.generatorTier);
                         }
-                        case "BUY" -> {
-                            if (this.island != null && this.manager.canPurchaseGenerator(user, this.island, this.generatorData, this.generatorTier))
-                            {
-                                this.manager.purchaseGenerator(this.user, this.island, this.generatorData, this.generatorTier);
-                            }
-
-                            // Build whole gui.
-                            this.build();
-                        }
+                        case "BUY" -> this.purchaseGenerator(this.island, this.generatorData, this.generatorTier);
                         case "ACTIVATE" -> {
                             if (this.island != null && this.manager.canActivateGenerator(user, this.island, this.generatorData, this.generatorTier))
                             {
@@ -1139,15 +1131,7 @@ public class GeneratorViewPanel extends CommonPanel
                         case "VIEW" -> {
                             GeneratorViewPanel.openPanel(this, this.generatorTier);
                         }
-                        case "BUY" -> {
-                            if (this.island != null && this.manager.canPurchaseGenerator(user, this.island, this.generatorData, this.generatorTier))
-                            {
-                                this.manager.purchaseGenerator(this.user, this.island, this.generatorData, this.generatorTier);
-                            }
-
-                            // Build whole gui.
-                            this.build();
-                        }
+                        case "BUY" -> this.purchaseGenerator(this.island, this.generatorData, this.generatorTier);
                         case "ACTIVATE" -> {
                             if (this.island != null && this.manager.canActivateGenerator(user, this.island, this.generatorData, this.generatorTier))
                             {

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1068,6 +1068,8 @@ stone-generator:
     write-permissions: "<yellow>Please enter the required permissions, one per line in chat, and 'quit' on a line by itself to finish.</yellow>"
     # Message that appears after successful permission updating.
     permissions-changed: "<green>Success, generator permissions were updated.</green>"
+    # Message that asks the player to confirm a generator purchase before money is taken.
+    confirm-generator-purchase: "<yellow>Please confirm that you want to buy </yellow>[generator]<yellow> for [number].</yellow>"
     # Message that appears after importing library data into database.
     confirm-data-replacement: "<yellow>Please confirm that you want to replace your current generators with new one.</yellow>"
     # Message that appears after successful data importing

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanelPurchaseTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanelPurchaseTest.java
@@ -1,0 +1,166 @@
+package world.bentobox.magiccobblestonegenerator.panels;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.magiccobblestonegenerator.CommonTestSetup;
+import world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon;
+import world.bentobox.magiccobblestonegenerator.config.Settings;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorDataObject;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+import world.bentobox.magiccobblestonegenerator.managers.StoneGeneratorManager;
+
+/**
+ * Tests for the shared purchase-with-confirmation helper in {@link CommonPanel} (#109).
+ */
+class CommonPanelPurchaseTest extends CommonTestSetup {
+
+    @Mock
+    private StoneGeneratorAddon addon;
+    @Mock
+    private StoneGeneratorManager manager;
+    @Mock
+    private User panelUser;
+    @Mock
+    private GeneratorDataObject generatorData;
+    @Mock
+    private GeneratorTierObject generatorTier;
+
+    private Settings settings;
+    private TestPanel panel;
+
+    /**
+     * Minimal concrete CommonPanel that counts build() calls.
+     */
+    private static class TestPanel extends CommonPanel {
+        int builds = 0;
+
+        TestPanel(StoneGeneratorAddon addon, User user, org.bukkit.World world) {
+            super(addon, user, world);
+        }
+
+        @Override
+        protected void build() {
+            this.builds++;
+        }
+
+        void purchase(Island island, GeneratorDataObject data, GeneratorTierObject tier) {
+            this.purchaseGenerator(island, data, tier);
+        }
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+
+        settings = new Settings();
+        when(addon.getSettings()).thenReturn(settings);
+        when(addon.getAddonManager()).thenReturn(manager);
+
+        when(panelUser.getLocale()).thenReturn(Locale.ENGLISH);
+        when(panelUser.getTranslation(anyString()))
+                .thenAnswer((Answer<String>) inv -> inv.getArgument(0, String.class));
+        when(panelUser.getTranslationOrNothing(anyString()))
+                .thenAnswer((Answer<String>) inv -> inv.getArgument(0, String.class));
+
+        when(generatorTier.getFriendlyName()).thenReturn("Basic Tier");
+
+        panel = new TestPanel(addon, panelUser, world);
+    }
+
+    @Test
+    void testSettingsBuyConfirmationDefaultsToTrue() {
+        assertTrue(new Settings().isBuyConfirmation());
+    }
+
+    @Test
+    void testCannotPurchaseDoesNotBuy() {
+        when(manager.canPurchaseGenerator(any(), any(), any(), any())).thenReturn(false);
+
+        panel.purchase(island, generatorData, generatorTier);
+
+        verify(manager, never()).purchaseGenerator(any(), any(), any(), any());
+        assertEquals(1, panel.builds);
+    }
+
+    @Test
+    void testConfirmationDisabledPurchasesDirectly() {
+        settings.setBuyConfirmation(false);
+        when(manager.canPurchaseGenerator(any(), any(), any(), any())).thenReturn(true);
+
+        try (MockedStatic<ConversationUtils> cu = Mockito.mockStatic(ConversationUtils.class)) {
+            panel.purchase(island, generatorData, generatorTier);
+
+            verify(manager).purchaseGenerator(panelUser, island, generatorData, generatorTier);
+            cu.verifyNoInteractions();
+        }
+        assertEquals(1, panel.builds);
+    }
+
+    @Test
+    void testConfirmationEnabledBuysOnlyAfterConfirm() {
+        settings.setBuyConfirmation(true);
+        when(manager.canPurchaseGenerator(any(), any(), any(), any())).thenReturn(true);
+
+        List<Consumer<Boolean>> captured = new ArrayList<>();
+        try (MockedStatic<ConversationUtils> cu = Mockito.mockStatic(ConversationUtils.class)) {
+            cu.when(() -> ConversationUtils.createConfirmation(any(), any(), any(), any()))
+                    .thenAnswer(inv -> {
+                        captured.add(inv.getArgument(0));
+                        return null;
+                    });
+
+            panel.purchase(island, generatorData, generatorTier);
+
+            // Nothing purchased until the player confirms.
+            verify(manager, never()).purchaseGenerator(any(), any(), any(), any());
+            assertEquals(1, captured.size());
+
+            // Player confirms.
+            captured.get(0).accept(true);
+            verify(manager).purchaseGenerator(panelUser, island, generatorData, generatorTier);
+        }
+    }
+
+    @Test
+    void testConfirmationEnabledDeclineDoesNotBuy() {
+        settings.setBuyConfirmation(true);
+        when(manager.canPurchaseGenerator(any(), any(), any(), any())).thenReturn(true);
+
+        List<Consumer<Boolean>> captured = new ArrayList<>();
+        try (MockedStatic<ConversationUtils> cu = Mockito.mockStatic(ConversationUtils.class)) {
+            cu.when(() -> ConversationUtils.createConfirmation(any(), any(), any(), any()))
+                    .thenAnswer(inv -> {
+                        captured.add(inv.getArgument(0));
+                        return null;
+                    });
+
+            panel.purchase(island, generatorData, generatorTier);
+            // Player declines.
+            captured.get(0).accept(false);
+
+            verify(manager, never()).purchaseGenerator(any(), any(), any(), any());
+        }
+    }
+}


### PR DESCRIPTION
Closes #109

## Problem
Players reported buying generators unwittingly — a single click on the BUY action purchases immediately.

## Change
Adds a `buy-confirmation` config option (default **true**). When enabled, buying a generator asks the player to confirm in chat before any money is taken.

The three BUY click handlers (`GeneratorUserPanel` ×1, `GeneratorViewPanel` ×2) previously duplicated the same purchase logic. They now delegate to a shared `CommonPanel.purchaseGenerator(island, data, tier)` helper, which:
- refreshes the panel and returns if the generator can't be purchased (the reason is already messaged by `canPurchaseGenerator`),
- purchases directly when confirmation is disabled,
- otherwise requests a chat confirmation via the existing `ConversationUtils.createConfirmation` and only purchases on confirm.

The chat-confirmation approach matches how this addon already confirms other actions (e.g. library data replacement).

## Added
- `Settings.buyConfirmation` (`buy-confirmation`, default true) + getter/setter.
- `stone-generator.conversations.confirm-generator-purchase` locale string (en-US).
- `CommonPanel.purchaseGenerator` shared helper.

## Tests
`CommonPanelPurchaseTest`:
- setting defaults to true,
- can't-purchase → no buy, panel rebuilt,
- confirmation disabled → buys directly, no conversation,
- confirmation enabled → buys only after confirm; decline → no buy.

Full suite: 66 tests pass.

> Note: uses a chat confirmation (consistent with existing confirmations). If a yes/no *button* GUI is preferred instead, that's a straightforward follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)