### PR TITLE
Add prerequisite-generator requirement (#88)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -200,6 +200,29 @@ public class GeneratorTierObject implements DataObject
 
 
     /**
+     * Method GeneratorTierObject#getRequiredGeneratorTiers returns the unique ids of generator tiers that must be
+     * unlocked before this generator becomes available.
+     *
+     * @return the requiredGeneratorTiers (type Set&lt;String&gt;) of this object.
+     */
+    public Set<String> getRequiredGeneratorTiers()
+    {
+        return requiredGeneratorTiers;
+    }
+
+
+    /**
+     * Method GeneratorTierObject#setRequiredGeneratorTiers sets new value for the requiredGeneratorTiers of this object.
+     *
+     * @param requiredGeneratorTiers new value for this object.
+     */
+    public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
+    {
+        this.requiredGeneratorTiers = requiredGeneratorTiers;
+    }
+
+
+    /**
      * Method GeneratorTierObject#getGeneratorTierCost returns the generatorTierCost of this object.
      *
      * @return the generatorTierCost (type double) of this object.
@@ -518,6 +541,7 @@ public class GeneratorTierObject implements DataObject
         clone.setRequiredMinIslandLevel(this.requiredMinIslandLevel);
         clone.setRequiredBiomes(new HashSet<>(this.requiredBiomes));
         clone.setRequiredPermissions(new HashSet<>(this.requiredPermissions));
+        clone.setRequiredGeneratorTiers(new HashSet<>(this.requiredGeneratorTiers));
         clone.setGeneratorTierCost(this.generatorTierCost);
         clone.setActivationCost(this.activationCost);
         clone.setDeployed(this.deployed);
@@ -663,6 +687,12 @@ public class GeneratorTierObject implements DataObject
      */
     @Expose
     private Set<String> requiredPermissions = Collections.emptySet();
+
+    /**
+     * Unique ids of generator tiers that must be unlocked before this generator becomes available.
+     */
+    @Expose
+    private Set<String> requiredGeneratorTiers = Collections.emptySet();
 
     /**
      * Cost to do buy current generator.

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -216,10 +216,10 @@ public class GeneratorTierObject implements DataObject
      *
      * @param requiredGeneratorTiers new value for this object.
      */
-    public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
-    {
-        this.requiredGeneratorTiers = requiredGeneratorTiers;
-    }
+public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
+{
+    this.requiredGeneratorTiers = requiredGeneratorTiers == null ? Collections.emptySet() : requiredGeneratorTiers;
+}
 
 
     /**

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -207,6 +207,13 @@ public class GeneratorTierObject implements DataObject
      */
     public Set<String> getRequiredGeneratorTiers()
     {
+        if (this.requiredGeneratorTiers == null)
+        {
+            // Guard against a null value from deserialization of user-edited JSON, so callers such as
+            // clone() and containsAll() never hit a NullPointerException.
+            this.requiredGeneratorTiers = new HashSet<>();
+        }
+
         return requiredGeneratorTiers;
     }
 
@@ -216,10 +223,10 @@ public class GeneratorTierObject implements DataObject
      *
      * @param requiredGeneratorTiers new value for this object.
      */
-public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
-{
-    this.requiredGeneratorTiers = requiredGeneratorTiers == null ? Collections.emptySet() : requiredGeneratorTiers;
-}
+    public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
+    {
+        this.requiredGeneratorTiers = requiredGeneratorTiers == null ? new HashSet<>() : requiredGeneratorTiers;
+    }
 
 
     /**
@@ -541,7 +548,7 @@ public void setRequiredGeneratorTiers(Set<String> requiredGeneratorTiers)
         clone.setRequiredMinIslandLevel(this.requiredMinIslandLevel);
         clone.setRequiredBiomes(new HashSet<>(this.requiredBiomes));
         clone.setRequiredPermissions(new HashSet<>(this.requiredPermissions));
-        clone.setRequiredGeneratorTiers(new HashSet<>(this.requiredGeneratorTiers));
+        clone.setRequiredGeneratorTiers(new HashSet<>(this.getRequiredGeneratorTiers()));
         clone.setGeneratorTierCost(this.generatorTierCost);
         clone.setActivationCost(this.activationCost);
         clone.setDeployed(this.deployed);

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -872,6 +872,11 @@ public class StoneGeneratorManager {
 		filter(generator -> generator.getRequiredPermissions().isEmpty() || owner != null && owner.isOnline()
 			&& Utils.matchAllPermissions(owner, generator.getRequiredPermissions()))
 		.
+		// Filter out generators whose prerequisite generators are not yet unlocked (#88).
+		// Generators are streamed in priority order, so a prerequisite with a lower priority
+		// is unlocked earlier in this same pass and is visible here.
+		filter(generator -> dataObject.getUnlockedTiers().containsAll(generator.getRequiredGeneratorTiers()))
+		.
 		// Now process each generator.
 		forEach(generator -> this.unlockGenerator(dataObject, user, island, generator));
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
@@ -584,9 +584,12 @@ public abstract class CommonPanel
             requiredGenerators.append(this.user.getTranslationOrNothing(reference + "required-generators-title"));
 
             generator.getRequiredGeneratorTiers().stream().
-                map(this.manager::getGeneratorByID).
-                filter(Objects::nonNull).
-                map(GeneratorTierObject::getFriendlyName).
+                // Fall back to the raw id if the generator can no longer be resolved (deleted/renamed),
+                // so a locked generator always shows what is blocking it.
+                map(id -> {
+                    GeneratorTierObject required = this.manager.getGeneratorByID(id);
+                    return required == null ? id : required.getFriendlyName();
+                }).
                 sorted().
                 forEach(name ->
                 {

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
@@ -577,10 +577,30 @@ public abstract class CommonPanel
             biomes.append(this.user.getTranslationOrNothing(reference + "any"));
         }
 
+        StringBuilder requiredGenerators = new StringBuilder();
+
+        if (!generator.getRequiredGeneratorTiers().isEmpty() && !isUnlocked)
+        {
+            requiredGenerators.append(this.user.getTranslationOrNothing(reference + "required-generators-title"));
+
+            generator.getRequiredGeneratorTiers().stream().
+                map(this.manager::getGeneratorByID).
+                filter(Objects::nonNull).
+                map(GeneratorTierObject::getFriendlyName).
+                sorted().
+                forEach(name ->
+                {
+                    requiredGenerators.append("\n");
+                    requiredGenerators.append(this.user.getTranslationOrNothing(reference + "required-generator",
+                        Constants.GENERATOR, name));
+                });
+        }
+
         return this.user.getTranslationOrNothing(reference + "description",
             "[biomes]", biomes.toString(),
             "[level]", level,
-            "[missing-permissions]", permissions.toString());
+            "[missing-permissions]", permissions.toString(),
+            "[required-generators]", requiredGenerators.toString());
     }
 
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -29,6 +30,7 @@ import world.bentobox.magiccobblestonegenerator.panels.CommonPanel;
 import world.bentobox.magiccobblestonegenerator.panels.ConversationUtils;
 import world.bentobox.magiccobblestonegenerator.panels.utils.GeneratorTypeSelector;
 import world.bentobox.magiccobblestonegenerator.panels.utils.MultiBiomeSelector;
+import world.bentobox.magiccobblestonegenerator.panels.utils.MultiGeneratorSelector;
 import world.bentobox.magiccobblestonegenerator.panels.utils.SingleBlockSelector;
 import world.bentobox.magiccobblestonegenerator.utils.Constants;
 import world.bentobox.magiccobblestonegenerator.utils.Pair;
@@ -180,6 +182,9 @@ public class GeneratorEditPanel extends CommonPanel
 
             // Display only permissions if they are required.
             panelBuilder.item(23, this.createButton(Button.REQUIRED_PERMISSIONS, locale));
+
+            // Prerequisite generators that must be unlocked first.
+            panelBuilder.item(31, this.createButton(Button.REQUIRED_GENERATORS, locale));
 
             if (this.addon.isVaultProvided())
             {
@@ -629,6 +634,65 @@ public class GeneratorEditPanel extends CommonPanel
                 description.add(this.user.getTranslation(Constants.TIPS + "click-to-change"));
 
                 if (!this.generatorTier.getRequiredPermissions().isEmpty())
+                {
+                    description.add(this.user.getTranslation(Constants.TIPS + "shift-click-to-reset"));
+                }
+            }
+            case REQUIRED_GENERATORS -> {
+                itemStack = new ItemStack(Material.CHISELED_BOOKSHELF);
+
+                description.add(this.user.getTranslation(reference + ".list"));
+
+                if (this.generatorTier.getRequiredGeneratorTiers().isEmpty())
+                {
+                    description.add(this.user.getTranslation(reference + ".none"));
+                }
+                else
+                {
+                    this.generatorTier.getRequiredGeneratorTiers().stream().
+                        map(this.manager::getGeneratorByID).
+                        filter(Objects::nonNull).
+                        map(GeneratorTierObject::getFriendlyName).
+                        sorted().
+                        forEach(generatorName -> description.add(this.user.getTranslation(reference + ".value",
+                            Constants.GENERATOR, generatorName)));
+                }
+
+                clickHandler = (panel, user, clickType, i) ->
+                {
+                    if (!this.generatorTier.getRequiredGeneratorTiers().isEmpty() && clickType.isShiftClick())
+                    {
+                        // Reset to the empty value.
+                        this.generatorTier.setRequiredGeneratorTiers(new HashSet<>());
+                        this.save();
+                        this.build();
+                    }
+                    else
+                    {
+                        MultiGeneratorSelector.open(user,
+                            this.addon,
+                            this.world,
+                            this.generatorTier,
+                            this.generatorTier.getRequiredGeneratorTiers(),
+                            value ->
+                            {
+                                if (value != null)
+                                {
+                                    this.generatorTier.setRequiredGeneratorTiers(new HashSet<>(value));
+                                    this.save();
+                                }
+
+                                this.build();
+                            });
+                    }
+
+                    return true;
+                };
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.TIPS + "click-to-change"));
+
+                if (!this.generatorTier.getRequiredGeneratorTiers().isEmpty())
                 {
                     description.add(this.user.getTranslation(Constants.TIPS + "shift-click-to-reset"));
                 }
@@ -1815,6 +1879,10 @@ public class GeneratorEditPanel extends CommonPanel
          * Holds Name type that allows to interact with generator required permissions.
          */
         REQUIRED_PERMISSIONS,
+        /**
+         * Holds Name type that allows to interact with generator prerequisite generators.
+         */
+        REQUIRED_GENERATORS,
         /**
          * Holds Name type that allows to interact with generator purchase cost.
          */

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -650,9 +649,12 @@ public class GeneratorEditPanel extends CommonPanel
                 else
                 {
                     this.generatorTier.getRequiredGeneratorTiers().stream().
-                        map(this.manager::getGeneratorByID).
-                        filter(Objects::nonNull).
-                        map(GeneratorTierObject::getFriendlyName).
+                        // Fall back to the raw id if the generator no longer exists, so the admin can
+                        // still see (and reset) which prerequisite is configured.
+                        map(id -> {
+                            GeneratorTierObject required = this.manager.getGeneratorByID(id);
+                            return required == null ? id : required.getFriendlyName();
+                        }).
                         sorted().
                         forEach(generatorName -> description.add(this.user.getTranslation(reference + ".value",
                             Constants.GENERATOR, generatorName)));

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
@@ -459,7 +459,7 @@ public class GeneratorEditPanel extends CommonPanel
 
                     if (!this.generatorTier.getDescription().isEmpty())
                     {
-                        description.add(this.user.getTranslation(Constants.TIPS + "shift-click-to-reset"));
+                        description.add(this.user.getTranslation(TIP_SHIFT_CLICK_TO_RESET));
                     }
 
                     return true;
@@ -587,7 +587,7 @@ public class GeneratorEditPanel extends CommonPanel
             case REQUIRED_PERMISSIONS -> {
                 itemStack = new ItemStack(Material.BOOK);
 
-                description.add(this.user.getTranslation(reference + ".list"));
+                description.add(this.user.getTranslation(reference + LIST_SUFFIX));
                 this.generatorTier.getRequiredPermissions().stream().sorted().forEach(permission ->
                 description.add(this.user.getTranslation(reference + ".value",
                     Constants.PERMISSION, permission)));
@@ -634,13 +634,13 @@ public class GeneratorEditPanel extends CommonPanel
 
                 if (!this.generatorTier.getRequiredPermissions().isEmpty())
                 {
-                    description.add(this.user.getTranslation(Constants.TIPS + "shift-click-to-reset"));
+                    description.add(this.user.getTranslation(TIP_SHIFT_CLICK_TO_RESET));
                 }
             }
             case REQUIRED_GENERATORS -> {
                 itemStack = new ItemStack(Material.CHISELED_BOOKSHELF);
 
-                description.add(this.user.getTranslation(reference + ".list"));
+                description.add(this.user.getTranslation(reference + LIST_SUFFIX));
 
                 if (this.generatorTier.getRequiredGeneratorTiers().isEmpty())
                 {
@@ -696,7 +696,7 @@ public class GeneratorEditPanel extends CommonPanel
 
                 if (!this.generatorTier.getRequiredGeneratorTiers().isEmpty())
                 {
-                    description.add(this.user.getTranslation(Constants.TIPS + "shift-click-to-reset"));
+                    description.add(this.user.getTranslation(TIP_SHIFT_CLICK_TO_RESET));
                 }
             }
             case PURCHASE_COST -> {
@@ -816,7 +816,7 @@ public class GeneratorEditPanel extends CommonPanel
             case BIOMES -> {
                 itemStack = new ItemStack(Material.FILLED_MAP);
 
-                description.add(this.user.getTranslation(reference + ".list"));
+                description.add(this.user.getTranslation(reference + LIST_SUFFIX));
 
                 if (this.generatorTier.getRequiredBiomes().isEmpty())
                 {
@@ -1931,6 +1931,16 @@ public class GeneratorEditPanel extends CommonPanel
     // ---------------------------------------------------------------------
     // Section: Variables
     // ---------------------------------------------------------------------
+
+    /**
+     * Reference for the "shift-click to reset" tip, reused by several requirement buttons.
+     */
+    private static final String TIP_SHIFT_CLICK_TO_RESET = Constants.TIPS + "shift-click-to-reset";
+
+    /**
+     * Suffix for the requirement list translation key, reused by several requirement buttons.
+     */
+    private static final String LIST_SUFFIX = ".list";
 
     /**
      * This variable stores generator tier that is viewed.

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
@@ -36,7 +36,7 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
      * @param world the world whose generators are shown
      * @param excluded a generator that must not be selectable (e.g. the one being edited), or null
      * @param selectedIds the currently selected generator ids
-     * @param consumer the consumer that receives the selected ids, or null if cancelled
+     * @param consumer the consumer that receives the selected ids, or receives null as the value if cancelled
      */
     private MultiGeneratorSelector(User user,
         StoneGeneratorAddon addon,
@@ -50,7 +50,9 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
         this.selectedIds = new LinkedHashSet<>(selectedIds);
 
         // Show all deployed generators in the world, except default generators and the excluded one.
+        // Non-deployed generators can never be unlocked, so they must not be selectable as prerequisites.
         this.elements = addon.getAddonManager().getAllGeneratorTiers(world).stream().
+            filter(GeneratorTierObject::isDeployed).
             filter(generator -> !generator.isDefaultGenerator()).
             filter(generator -> excluded == null || !generator.getUniqueId().equals(excluded.getUniqueId())).
             sorted(Comparator.comparing(GeneratorTierObject::getFriendlyName)).
@@ -216,7 +218,7 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
      * @param world the world whose generators are shown
      * @param excluded a generator that must not be selectable, or null
      * @param selectedIds the currently selected generator ids
-     * @param consumer the consumer that receives the selected ids, or null if cancelled
+     * @param consumer the consumer that receives the selected ids, or receives null as the value if cancelled
      */
     public static void open(User user,
         StoneGeneratorAddon addon,

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -49,14 +48,16 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
         this.consumer = consumer;
         this.selectedIds = new LinkedHashSet<>(selectedIds);
 
-        // Show all deployed generators in the world, except default generators and the excluded one.
-        // Non-deployed generators can never be unlocked, so they must not be selectable as prerequisites.
+        // Show deployed, non-default generators (valid prerequisites), plus any generator that is already selected
+        // even if it would otherwise be filtered out (e.g. undeployed/default), so existing selections remain
+        // visible and can be deselected. The excluded generator (the one being edited) is never shown.
+        // Non-deployed generators can never be unlocked, so they must not be selectable as *new* prerequisites.
         this.elements = addon.getAddonManager().getAllGeneratorTiers(world).stream().
-            filter(GeneratorTierObject::isDeployed).
-            filter(generator -> !generator.isDefaultGenerator()).
             filter(generator -> excluded == null || !generator.getUniqueId().equals(excluded.getUniqueId())).
+            filter(generator -> (generator.isDeployed() && !generator.isDefaultGenerator())
+                || this.selectedIds.contains(generator.getUniqueId())).
             sorted(Comparator.comparing(GeneratorTierObject::getFriendlyName)).
-            collect(Collectors.toList());
+            toList();
 
         this.filterElements = this.elements;
     }
@@ -97,7 +98,7 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
             this.filterElements = this.elements.stream().
                 filter(element -> element.getFriendlyName().toLowerCase().contains(this.searchString.toLowerCase())).
                 distinct().
-                collect(Collectors.toList());
+                toList();
         }
     }
 
@@ -118,44 +119,43 @@ public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
         PanelItem.ClickHandler clickHandler;
         Material icon;
 
-        switch (button)
+        if (button == Action.ACCEPT_GENERATOR)
         {
-            case ACCEPT_GENERATOR -> {
-                description.add(this.user.getTranslationOrNothing(reference + ".description"));
+            description.add(this.user.getTranslationOrNothing(reference + ".description"));
 
-                if (!this.selectedIds.isEmpty())
-                {
-                    description.add(this.user.getTranslation(reference + ".selected-generators"));
+            if (!this.selectedIds.isEmpty())
+            {
+                description.add(this.user.getTranslation(reference + ".selected-generators"));
 
-                    this.elements.stream().
-                        filter(generator -> this.selectedIds.contains(generator.getUniqueId())).
-                        forEach(generator -> description.add(this.user.getTranslation(reference + ".list-value",
-                            Constants.VALUE, generator.getFriendlyName())));
-                }
-
-                description.add("");
-                description.add(this.user.getTranslation(Constants.TIPS + "click-to-accept"));
-
-                clickHandler = (panel, user, clickType, i) -> {
-                    this.consumer.accept(this.selectedIds);
-                    return true;
-                };
-
-                icon = Material.FILLED_MAP;
+                this.elements.stream().
+                    filter(generator -> this.selectedIds.contains(generator.getUniqueId())).
+                    forEach(generator -> description.add(this.user.getTranslation(reference + ".list-value",
+                        Constants.VALUE, generator.getFriendlyName())));
             }
-            default -> {
-                description.add(this.user.getTranslationOrNothing(reference + ".description"));
 
-                description.add("");
-                description.add(this.user.getTranslation(Constants.TIPS + "click-to-cancel"));
+            description.add("");
+            description.add(this.user.getTranslation(Constants.TIPS + "click-to-accept"));
 
-                clickHandler = (panel, user, clickType, i) -> {
-                    this.consumer.accept(null);
-                    return true;
-                };
+            clickHandler = (panel, user, clickType, i) -> {
+                this.consumer.accept(this.selectedIds);
+                return true;
+            };
 
-                icon = Material.OAK_DOOR;
-            }
+            icon = Material.FILLED_MAP;
+        }
+        else
+        {
+            description.add(this.user.getTranslationOrNothing(reference + ".description"));
+
+            description.add("");
+            description.add(this.user.getTranslation(Constants.TIPS + "click-to-cancel"));
+
+            clickHandler = (panel, user, clickType, i) -> {
+                this.consumer.accept(null);
+                return true;
+            };
+
+            icon = Material.OAK_DOOR;
         }
 
         return new PanelItemBuilder().

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/utils/MultiGeneratorSelector.java
@@ -1,0 +1,270 @@
+package world.bentobox.magiccobblestonegenerator.panels.utils;
+
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+
+import lv.id.bonne.panelutils.PanelUtils;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon;
+import world.bentobox.magiccobblestonegenerator.database.objects.GeneratorTierObject;
+import world.bentobox.magiccobblestonegenerator.utils.Constants;
+
+
+/**
+ * This Panel allows to select multiple generator tiers, used for choosing prerequisite generators. It returns the
+ * selected generators' unique ids.
+ */
+public class MultiGeneratorSelector extends PagedSelector<GeneratorTierObject>
+{
+    /**
+     * Instantiates a new Multi generator selector.
+     *
+     * @param user the user
+     * @param addon the addon
+     * @param world the world whose generators are shown
+     * @param excluded a generator that must not be selectable (e.g. the one being edited), or null
+     * @param selectedIds the currently selected generator ids
+     * @param consumer the consumer that receives the selected ids, or null if cancelled
+     */
+    private MultiGeneratorSelector(User user,
+        StoneGeneratorAddon addon,
+        World world,
+        GeneratorTierObject excluded,
+        Set<String> selectedIds,
+        Consumer<Set<String>> consumer)
+    {
+        super(user);
+        this.consumer = consumer;
+        this.selectedIds = new LinkedHashSet<>(selectedIds);
+
+        // Show all deployed generators in the world, except default generators and the excluded one.
+        this.elements = addon.getAddonManager().getAllGeneratorTiers(world).stream().
+            filter(generator -> !generator.isDefaultGenerator()).
+            filter(generator -> excluded == null || !generator.getUniqueId().equals(excluded.getUniqueId())).
+            sorted(Comparator.comparing(GeneratorTierObject::getFriendlyName)).
+            collect(Collectors.toList());
+
+        this.filterElements = this.elements;
+    }
+
+
+    /**
+     * This method builds panel that allows to select generators.
+     */
+    @Override
+    protected void build()
+    {
+        PanelBuilder panelBuilder = new PanelBuilder().user(this.user);
+        panelBuilder.name(this.user.getTranslation(Constants.TITLE + "select-generator"));
+
+        PanelUtils.fillBorder(panelBuilder, Material.BLUE_STAINED_GLASS_PANE);
+
+        this.populateElements(panelBuilder, this.filterElements);
+
+        panelBuilder.item(39, this.createButton(Action.ACCEPT_GENERATOR));
+        panelBuilder.item(44, this.createButton(Action.RETURN));
+
+        panelBuilder.build();
+    }
+
+
+    /**
+     * This method is called when filter value is updated.
+     */
+    @Override
+    protected void updateFilters()
+    {
+        if (this.searchString == null || this.searchString.isBlank())
+        {
+            this.filterElements = this.elements;
+        }
+        else
+        {
+            this.filterElements = this.elements.stream().
+                filter(element -> element.getFriendlyName().toLowerCase().contains(this.searchString.toLowerCase())).
+                distinct().
+                collect(Collectors.toList());
+        }
+    }
+
+
+    /**
+     * This method creates panel item for given button type.
+     *
+     * @param button Button type.
+     * @return Clickable PanelItem button.
+     */
+    private PanelItem createButton(Action button)
+    {
+        final String reference = Constants.BUTTON + button.name().toLowerCase();
+
+        String name = this.user.getTranslation(reference + ".name");
+        List<String> description = new ArrayList<>();
+
+        PanelItem.ClickHandler clickHandler;
+        Material icon;
+
+        switch (button)
+        {
+            case ACCEPT_GENERATOR -> {
+                description.add(this.user.getTranslationOrNothing(reference + ".description"));
+
+                if (!this.selectedIds.isEmpty())
+                {
+                    description.add(this.user.getTranslation(reference + ".selected-generators"));
+
+                    this.elements.stream().
+                        filter(generator -> this.selectedIds.contains(generator.getUniqueId())).
+                        forEach(generator -> description.add(this.user.getTranslation(reference + ".list-value",
+                            Constants.VALUE, generator.getFriendlyName())));
+                }
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.TIPS + "click-to-accept"));
+
+                clickHandler = (panel, user, clickType, i) -> {
+                    this.consumer.accept(this.selectedIds);
+                    return true;
+                };
+
+                icon = Material.FILLED_MAP;
+            }
+            default -> {
+                description.add(this.user.getTranslationOrNothing(reference + ".description"));
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.TIPS + "click-to-cancel"));
+
+                clickHandler = (panel, user, clickType, i) -> {
+                    this.consumer.accept(null);
+                    return true;
+                };
+
+                icon = Material.OAK_DOOR;
+            }
+        }
+
+        return new PanelItemBuilder().
+            name(name).
+            description(description).
+            amount(1).
+            icon(icon).
+            clickHandler(clickHandler).
+            build();
+    }
+
+
+    /**
+     * This method builds PanelItem for given generator.
+     *
+     * @param generator Generator which PanelItem must be created.
+     * @return new PanelItem for given generator.
+     */
+    @Override
+    protected PanelItem createElementButton(GeneratorTierObject generator)
+    {
+        List<String> description = new ArrayList<>();
+
+        if (this.selectedIds.contains(generator.getUniqueId()))
+        {
+            description.add(this.user.getTranslation(Constants.DESCRIPTIONS + "selected"));
+            description.add("");
+            description.add(this.user.getTranslationOrNothing(Constants.TIPS + "click-to-deselect"));
+        }
+        else
+        {
+            description.add(this.user.getTranslationOrNothing(Constants.TIPS + "click-to-select"));
+        }
+
+        return new PanelItemBuilder().
+            name(generator.getFriendlyName()).
+            description(description).
+            icon(generator.getGeneratorIcon().clone()).
+            clickHandler((panel, user1, clickType, slot) -> {
+                if (!this.selectedIds.remove(generator.getUniqueId()))
+                {
+                    this.selectedIds.add(generator.getUniqueId());
+                }
+
+                // update icons
+                panel.getInventory().setItem(slot, this.createElementButton(generator).getItem());
+                panel.getInventory().setItem(39, this.createButton(Action.ACCEPT_GENERATOR).getItem());
+                return true;
+            }).
+            glow(this.selectedIds.contains(generator.getUniqueId())).
+            build();
+    }
+
+
+    /**
+     * Opens panel for this class without necessity to create new class instance.
+     *
+     * @param user the user
+     * @param addon the addon
+     * @param world the world whose generators are shown
+     * @param excluded a generator that must not be selectable, or null
+     * @param selectedIds the currently selected generator ids
+     * @param consumer the consumer that receives the selected ids, or null if cancelled
+     */
+    public static void open(User user,
+        StoneGeneratorAddon addon,
+        World world,
+        GeneratorTierObject excluded,
+        Set<String> selectedIds,
+        Consumer<Set<String>> consumer)
+    {
+        new MultiGeneratorSelector(user, addon, world, excluded, selectedIds, consumer).build();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Enum
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Stores all available actions for Panel.
+     */
+    private enum Action
+    {
+        RETURN,
+        ACCEPT_GENERATOR
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+    /**
+     * This variable stores consumer.
+     */
+    private final Consumer<Set<String>> consumer;
+
+    /**
+     * List with elements that will be displayed in current GUI.
+     */
+    private final List<GeneratorTierObject> elements;
+
+    /**
+     * Selected generator ids.
+     */
+    private final Set<String> selectedIds;
+
+    /**
+     * Stores filtered items.
+     */
+    private List<GeneratorTierObject> filterElements;
+}

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -45,6 +45,7 @@ stone-generator:
       admin-panel: "<black><bold>Admin Panel</bold></black>"
       # Title for GUI that allows to select biomes for generator.
       select-biome: "<black><bold>Select Biomes</bold></black>"
+      select-generator: "<black><bold>Select Generators</bold></black>"
       # Title for GUI that allows to select a block generator.
       select-block: "<black><bold>Select Block</bold></black>"
       # Title for GUI that allows to select a bundle for island.
@@ -128,6 +129,15 @@ stone-generator:
           </gray><gray>this generator.</gray>
         list: "<aqua>Required Permissions:</aqua>"
         value: "<aqua>- [permission]</aqua>"
+        none: "<aqua>- none</aqua>"
+      required_generators:
+        name: "<white><bold>Required Generators</bold></white>"
+        description: |-
+          <gray>Generators that must be
+          </gray><gray>unlocked before this
+          </gray><gray>generator becomes available.</gray>
+        list: "<aqua>Required Generators:</aqua>"
+        value: "<aqua>- [generator]</aqua>"
         none: "<aqua>- none</aqua>"
       purchase_cost:
         name: "<white><bold>Purchase Cost</bold></white>"
@@ -682,6 +692,13 @@ stone-generator:
           <gray>Accepts selected biomes
           </gray><gray>and returns.</gray>
         selected-biomes: "<gray>Selected Biomes:</gray>"
+        list-value: "<gray>- [value]</gray>"
+      accept_generator:
+        name: "<white><bold>Accept the generators</bold></white>"
+        description: |-
+          <gray>Accepts selected generators
+          </gray><gray>and returns.</gray>
+        selected-generators: "<gray>Selected Generators:</gray>"
         list-value: "<gray>- [value]</gray>"
       biome-icon:
         name: "<white><bold>[biome]</bold></white>"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -890,9 +890,14 @@ stone-generator:
           description: |-
             [biomes]
             [level]
+            [required-generators]
             [missing-permissions]
           # Generates [level] message.
           level: "<red><bold>Required Level: </bold></red><red>[number]</red>"
+          # Generates [required-generators] message title.
+          required-generators-title: "<red><bold>Required Generators:</bold></red>"
+          # Generates [required-generators] message values.
+          required-generator: "<red> -[generator]</red>"
           # Generates [missing-permission] message title.
           permission-title: "<red><bold>Missing Permissions:</bold></red>"
           # Generates [missing-permission] message values.

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
@@ -30,6 +30,15 @@ class GeneratorTierObjectTest extends CommonTestSetup {
     }
 
     @Test
+    void testSetRequiredGeneratorTiersNullNormalizedToEmpty() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setRequiredGeneratorTiers(null);
+        assertTrue(tier.getRequiredGeneratorTiers().isEmpty());
+        // clone must not throw on a set that was normalized from null.
+        assertTrue(tier.clone().getRequiredGeneratorTiers().isEmpty());
+    }
+
+    @Test
     void testCloneCopiesRequiredGeneratorTiersIndependently() {
         GeneratorTierObject tier = new GeneratorTierObject();
         tier.setUniqueId("tier");

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
@@ -1,0 +1,45 @@
+package world.bentobox.magiccobblestonegenerator.database.objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.magiccobblestonegenerator.CommonTestSetup;
+
+/**
+ * Tests for the requiredGeneratorTiers field of {@link GeneratorTierObject} (#88).
+ */
+class GeneratorTierObjectTest extends CommonTestSetup {
+
+    @Test
+    void testRequiredGeneratorTiersDefaultsToEmpty() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        assertTrue(tier.getRequiredGeneratorTiers().isEmpty());
+    }
+
+    @Test
+    void testSetAndGetRequiredGeneratorTiers() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setRequiredGeneratorTiers(new HashSet<>(Set.of("gen1", "gen2")));
+        assertEquals(Set.of("gen1", "gen2"), tier.getRequiredGeneratorTiers());
+    }
+
+    @Test
+    void testCloneCopiesRequiredGeneratorTiersIndependently() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setUniqueId("tier");
+        tier.setRequiredGeneratorTiers(new HashSet<>(Set.of("gen1")));
+
+        GeneratorTierObject clone = tier.clone();
+        assertEquals(Set.of("gen1"), clone.getRequiredGeneratorTiers());
+
+        // The clone must hold an independent copy.
+        clone.getRequiredGeneratorTiers().add("gen2");
+        assertFalse(tier.getRequiredGeneratorTiers().contains("gen2"));
+    }
+}

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -430,6 +430,77 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
         assertTrue(data.getActiveGeneratorList().contains("magiccobblegenerator_perm"));
     }
 
+    /**
+     * Builds a deployed, non-default cobblestone generator tier mock with no permission/level requirements, for
+     * prerequisite-generator tests.
+     */
+    private GeneratorTierObject prerequisiteTier(String id, String name, int priority) {
+        GeneratorTierObject t = mock(GeneratorTierObject.class);
+        when(t.getUniqueId()).thenReturn(id);
+        when(t.getFriendlyName()).thenReturn(name);
+        when(t.getPriority()).thenReturn(priority);
+        when(t.getGeneratorType()).thenReturn(GeneratorType.COBBLESTONE);
+        when(t.isDeployed()).thenReturn(true);
+        when(t.isDefaultGenerator()).thenReturn(false);
+        when(t.getRequiredMinIslandLevel()).thenReturn(0L);
+        when(t.getRequiredPermissions()).thenReturn(java.util.Collections.emptySet());
+        when(t.getRequiredGeneratorTiers()).thenReturn(java.util.Collections.emptySet());
+        return t;
+    }
+
+    @Test
+    void testCheckGeneratorUnlockStatusUnlocksDependentWhenPrerequisiteUnlocked() {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-88");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+        s.setNotifyUnlockedGenerators(false);
+
+        GeneratorTierObject gen1 = prerequisiteTier("magiccobblegenerator_gen1", "Gen1", 10);
+        GeneratorTierObject gen2 = prerequisiteTier("magiccobblegenerator_gen2", "Gen2", 20);
+        when(gen2.getRequiredGeneratorTiers())
+                .thenReturn(java.util.Set.of("magiccobblegenerator_gen1"));
+        sgm.loadGeneratorTier(gen1, true, null);
+        sgm.loadGeneratorTier(gen2, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        // Gen1 has no requirements, so it unlocks; Gen2's prerequisite is then satisfied in the same pass.
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_gen1"));
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_gen2"));
+    }
+
+    @Test
+    void testCheckGeneratorUnlockStatusKeepsDependentLockedWhenPrerequisiteLocked() {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-88");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+        s.setNotifyUnlockedGenerators(false);
+
+        // Gen1 requires a permission the (offline) owner does not have, so it cannot unlock.
+        GeneratorTierObject gen1 = prerequisiteTier("magiccobblegenerator_gen1", "Gen1", 10);
+        when(gen1.getRequiredPermissions())
+                .thenReturn(java.util.Set.of("magiccobblegenerator.gen1"));
+        GeneratorTierObject gen2 = prerequisiteTier("magiccobblegenerator_gen2", "Gen2", 20);
+        when(gen2.getRequiredGeneratorTiers())
+                .thenReturn(java.util.Set.of("magiccobblegenerator_gen1"));
+        sgm.loadGeneratorTier(gen1, true, null);
+        sgm.loadGeneratorTier(gen2, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        // Gen1 stays locked, so Gen2's prerequisite is unmet and it stays locked too.
+        assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_gen1"));
+        assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_gen2"));
+    }
+
     @Test
     void testGetGeneratorDataIsland() {
         assertNotNull(sgm.getGeneratorData(island));


### PR DESCRIPTION
Closes #88

## Feature
Generators can now require **other generator tiers to be unlocked** before they become available, enabling progression chains — e.g. you must have Gen1 before Gen2 unlocks.

## Change
- **Data model:** `GeneratorTierObject` gains a `requiredGeneratorTiers` set of generator unique ids (`@Expose`, persisted; copied in `clone()`). Defaults to empty, so existing generators are unaffected.
- **Enforcement:** `checkGeneratorUnlockStatus` only unlocks a generator once **all** of its `requiredGeneratorTiers` are already in the island's unlocked set. Generators are streamed in priority order, so a lower-priority prerequisite unlocks earlier in the same pass and is visible to its dependents (set prerequisites to a lower `priority` than their dependents).
- **Display:** the requirements lore shows a "Required Generators" section for locked generators. Unresolvable ids (deleted/renamed) fall back to showing the raw id rather than being dropped.
- **Admin GUI:** a `MultiGeneratorSelector` (paged, searchable, multi-select of **deployed** generators) and a `REQUIRED_GENERATORS` button in the generator edit panel (shift-click resets). Prerequisites are also configurable via generator export/import JSON.

A prerequisite counts as satisfied when it is **unlocked** — the general "has access" gate, which works for both free and paid tiers.

## Tests
- `StoneGeneratorManagerTest`: dependent unlocks when prerequisite unlocked; stays locked when prerequisite blocked.
- `GeneratorTierObjectTest`: field default, accessors, clone copy.

Full suite passes.

> Note: this branch and #159 (#106) both add `GeneratorTierObjectTest`; whichever merges second will hit a trivial add/add conflict on that file (keep both classes' methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)