### PR TITLE
Add activate-on-unlock option for generators (#106)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -274,6 +274,29 @@ public class GeneratorTierObject implements DataObject
 
 
     /**
+     * Method GeneratorTierObject#isActivateOnUnlock returns whether this generator should be automatically activated as
+     * soon as it is unlocked.
+     *
+     * @return the activateOnUnlock (type boolean) of this object.
+     */
+    public boolean isActivateOnUnlock()
+    {
+        return activateOnUnlock;
+    }
+
+
+    /**
+     * Method GeneratorTierObject#setActivateOnUnlock sets new value for the activateOnUnlock of this object.
+     *
+     * @param activateOnUnlock new value for this object.
+     */
+    public void setActivateOnUnlock(boolean activateOnUnlock)
+    {
+        this.activateOnUnlock = activateOnUnlock;
+    }
+
+
+    /**
      * Returns the blockChanceMap of this object.
      *
      * @return a {@code TreeMap} where the keys are {@code Double} values representing chances,
@@ -552,6 +575,7 @@ public class GeneratorTierObject implements DataObject
         clone.setGeneratorTierCost(this.generatorTierCost);
         clone.setActivationCost(this.activationCost);
         clone.setDeployed(this.deployed);
+        clone.setActivateOnUnlock(this.activateOnUnlock);
         clone.setBlockChanceMap(new TreeMap<>(this.blockChanceMap));
 
         if (treasureChanceMap != null)
@@ -718,6 +742,12 @@ public class GeneratorTierObject implements DataObject
      */
     @Expose
     private boolean deployed = true;
+
+    /**
+     * Whether this generator is automatically activated as soon as it is unlocked.
+     */
+    @Expose
+    private boolean activateOnUnlock = false;
 
     // Rewards section
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -988,9 +988,8 @@ public class StoneGeneratorManager {
 	    this.saveGeneratorData(dataObject);
 
 	    // If configured, automatically activate the generator now that it is unlocked (#106).
-	    if (generator.isActivateOnUnlock()) {
-		this.autoActivateGenerator(dataObject, user, island, generator);
-		// Generator is active now; the click-to-activate notification is not relevant.
+	    // Only skip the click-to-activate notification if it actually activated.
+	    if (generator.isActivateOnUnlock() && this.autoActivateGenerator(dataObject, user, island, generator)) {
 		return;
 	    }
 
@@ -1023,33 +1022,53 @@ public class StoneGeneratorManager {
      * @param user       The user that triggered the unlock, or null.
      * @param island     The island the generator belongs to.
      * @param generator  The generator to activate.
+     * @return {@code true} if the generator was (or already is) active, {@code false} if it could not be activated
+     *         (active limit reached without overwrite, or the activation event was cancelled).
      */
-    private void autoActivateGenerator(@NotNull GeneratorDataObject dataObject, @Nullable User user,
+    private boolean autoActivateGenerator(@NotNull GeneratorDataObject dataObject, @Nullable User user,
 	    @NotNull Island island, @NotNull GeneratorTierObject generator) {
 	if (dataObject.getActiveGeneratorList().contains(generator.getUniqueId())) {
-	    // Already active.
-	    return;
+	    // Already active; no click-to-activate notification is needed.
+	    return true;
 	}
 
-	// Respect the active generator limit.
-	if (dataObject.getActiveGeneratorCount() > 0
-		&& dataObject.getActiveGeneratorList().size() >= dataObject.getActiveGeneratorCount()) {
-	    if (this.addon.getSettings().isOverwriteOnActive()) {
-		// Make room by removing the first active generator.
-		String oldId = dataObject.getActiveGeneratorList().iterator().next();
-		dataObject.getActiveGeneratorList().remove(oldId);
-	    } else {
-		// No room and overwrite disabled: leave the generator unlocked but inactive.
-		return;
-	    }
+	// Check the active generator limit up front. When it is reached and overwrite is disabled, we cannot
+	// activate, so report failure and let the caller send the normal unlock notification instead.
+	boolean atLimit = dataObject.getActiveGeneratorCount() > 0
+		&& dataObject.getActiveGeneratorList().size() >= dataObject.getActiveGeneratorCount();
+
+	if (atLimit && !this.addon.getSettings().isOverwriteOnActive()) {
+	    return false;
 	}
 
-	// Fire the activation event so other plugins can react or cancel.
+	// Fire the activation event before mutating anything, so a cancellation does not lose an already active
+	// generator.
 	GeneratorActivationEvent event = new GeneratorActivationEvent(generator, user, island.getUniqueId(), true);
 	Bukkit.getPluginManager().callEvent(event);
 
 	if (event.isCancelled()) {
-	    return;
+	    return false;
+	}
+
+	if (atLimit) {
+	    // Overwrite is enabled: free a slot by deactivating the first active generator. Prefer
+	    // deactivateGenerator so the deactivation event is fired, but that requires a user; otherwise remove
+	    // directly (system unlock).
+	    String oldId = dataObject.getActiveGeneratorList().iterator().next();
+	    GeneratorTierObject oldGenerator = this.getGeneratorByID(oldId);
+
+	    boolean freed;
+
+	    if (user != null && oldGenerator != null) {
+		freed = this.deactivateGenerator(user, dataObject, oldGenerator);
+	    } else {
+		freed = dataObject.getActiveGeneratorList().remove(oldId);
+	    }
+
+	    if (!freed) {
+		// Could not free a slot (e.g. the deactivation event was cancelled). Do not activate.
+		return false;
+	    }
 	}
 
 	dataObject.getActiveGeneratorList().add(generator.getUniqueId());
@@ -1058,7 +1077,15 @@ public class StoneGeneratorManager {
 	if (user != null) {
 	    Utils.sendMessage(user, user.getTranslation(Constants.MESSAGES + "generator-activated",
 		    Constants.GENERATOR, generator.getFriendlyName()));
+
+	    // Warn the user if the generator cannot actually operate because the addon is disabled on the island.
+	    if (!island.isAllowed(StoneGeneratorAddon.MAGIC_COBBLESTONE_GENERATOR)) {
+		Utils.sendMessage(user,
+			user.getTranslation(StoneGeneratorAddon.MAGIC_COBBLESTONE_GENERATOR.getHintReference()));
+	    }
 	}
+
+	return true;
     }
 
     /**

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -987,6 +987,13 @@ public class StoneGeneratorManager {
 	    // save data.
 	    this.saveGeneratorData(dataObject);
 
+	    // If configured, automatically activate the generator now that it is unlocked (#106).
+	    if (generator.isActivateOnUnlock()) {
+		this.autoActivateGenerator(dataObject, user, island, generator);
+		// Generator is active now; the click-to-activate notification is not relevant.
+		return;
+	    }
+
 	    if (!this.addon.getSettings().isNotifyUnlockedGenerators()) {
 		// Not necessary to notify users.
 		return;
@@ -1004,6 +1011,53 @@ public class StoneGeneratorManager {
 		island.getMemberSet()
 			.forEach(uuid -> Utils.sendUnlockMessage(uuid, island, generator, this.addon, true));
 	    }
+	}
+    }
+
+    /**
+     * This method automatically activates the given generator for the island once it is unlocked, respecting the active
+     * generator limit and the overwrite-on-active setting. It works without a user (system unlocks), so no cost is
+     * charged.
+     *
+     * @param dataObject Data that stores island generators.
+     * @param user       The user that triggered the unlock, or null.
+     * @param island     The island the generator belongs to.
+     * @param generator  The generator to activate.
+     */
+    private void autoActivateGenerator(@NotNull GeneratorDataObject dataObject, @Nullable User user,
+	    @NotNull Island island, @NotNull GeneratorTierObject generator) {
+	if (dataObject.getActiveGeneratorList().contains(generator.getUniqueId())) {
+	    // Already active.
+	    return;
+	}
+
+	// Respect the active generator limit.
+	if (dataObject.getActiveGeneratorCount() > 0
+		&& dataObject.getActiveGeneratorList().size() >= dataObject.getActiveGeneratorCount()) {
+	    if (this.addon.getSettings().isOverwriteOnActive()) {
+		// Make room by removing the first active generator.
+		String oldId = dataObject.getActiveGeneratorList().iterator().next();
+		dataObject.getActiveGeneratorList().remove(oldId);
+	    } else {
+		// No room and overwrite disabled: leave the generator unlocked but inactive.
+		return;
+	    }
+	}
+
+	// Fire the activation event so other plugins can react or cancel.
+	GeneratorActivationEvent event = new GeneratorActivationEvent(generator, user, island.getUniqueId(), true);
+	Bukkit.getPluginManager().callEvent(event);
+
+	if (event.isCancelled()) {
+	    return;
+	}
+
+	dataObject.getActiveGeneratorList().add(generator.getUniqueId());
+	this.saveGeneratorData(dataObject);
+
+	if (user != null) {
+	    Utils.sendMessage(user, user.getTranslation(Constants.MESSAGES + "generator-activated",
+		    Constants.GENERATOR, generator.getFriendlyName()));
 	}
     }
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/admin/GeneratorEditPanel.java
@@ -206,6 +206,9 @@ public class GeneratorEditPanel extends CommonPanel
         // deployed button.
         panelBuilder.item(33, this.createButton(Button.DEPLOYED, locale));
 
+        // Auto-activate on unlock toggle.
+        panelBuilder.item(29, this.createButton(Button.ACTIVATE_ON_UNLOCK, locale));
+
         // display treasures.
         panelBuilder.item(25, this.createButton(Button.TREASURE_CHANCE, locale));
         panelBuilder.item(34, this.createButton(Button.TREASURE_AMOUNT, locale));
@@ -872,6 +875,32 @@ public class GeneratorEditPanel extends CommonPanel
                 };
 
                 glow = this.generatorTier.isDeployed();
+
+                description.add("");
+                description.add(this.user.getTranslation(Constants.TIPS + "click-to-toggle"));
+            }
+            case ACTIVATE_ON_UNLOCK -> {
+                itemStack = new ItemStack(Material.REDSTONE_TORCH);
+
+                if (this.generatorTier.isActivateOnUnlock())
+                {
+                    description.add(this.user.getTranslation(reference + ".enabled"));
+                }
+                else
+                {
+                    description.add(this.user.getTranslation(reference + ".disabled"));
+                }
+
+                clickHandler = (panel, user, clickType, i) ->
+                {
+                    this.generatorTier.setActivateOnUnlock(!this.generatorTier.isActivateOnUnlock());
+                    this.save();
+                    this.build();
+
+                    return true;
+                };
+
+                glow = this.generatorTier.isActivateOnUnlock();
 
                 description.add("");
                 description.add(this.user.getTranslation(Constants.TIPS + "click-to-toggle"));
@@ -1901,6 +1930,10 @@ public class GeneratorEditPanel extends CommonPanel
          * Holds Name type that allows to interact with generator deployment status.
          */
         DEPLOYED,
+        /**
+         * Holds Name type that toggles whether the generator activates automatically on unlock.
+         */
+        ACTIVATE_ON_UNLOCK,
         /**
          * Holds Name type that allows to interact with generator treasure amount.
          */

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -412,6 +412,16 @@ stone-generator:
           <aqua>This generator is </aqua><green>deployed.</green>
         disabled: |-
           <aqua>This generator is </aqua><red>not deployed.</red>
+      activate_on_unlock:
+        name: "<white><bold>Activate On Unlock</bold></white>"
+        description: |-
+          <gray>When enabled, this generator
+          </gray><gray>is activated automatically
+          </gray><gray>as soon as it is unlocked.</gray>
+        enabled: |-
+          <aqua>This generator </aqua><green>activates on unlock.</green>
+        disabled: |-
+          <aqua>This generator </aqua><red>does not activate on unlock.</red>
       add_material:
         name: "<white><bold>Add Material</bold></white>"
         description: |-

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import world.bentobox.magiccobblestonegenerator.CommonTestSetup;
 
 /**
- * Tests for the requiredGeneratorTiers field of {@link GeneratorTierObject} (#88).
+ * Tests for the requiredGeneratorTiers (#88) and activateOnUnlock (#106) fields of {@link GeneratorTierObject}.
  */
 class GeneratorTierObjectTest extends CommonTestSetup {
 
@@ -50,5 +50,28 @@ class GeneratorTierObjectTest extends CommonTestSetup {
         // The clone must hold an independent copy.
         clone.getRequiredGeneratorTiers().add("gen2");
         assertFalse(tier.getRequiredGeneratorTiers().contains("gen2"));
+    }
+
+    @Test
+    void testActivateOnUnlockDefaultsToFalse() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        assertFalse(tier.isActivateOnUnlock());
+    }
+
+    @Test
+    void testSetAndGetActivateOnUnlock() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setActivateOnUnlock(true);
+        assertTrue(tier.isActivateOnUnlock());
+    }
+
+    @Test
+    void testCloneCopiesActivateOnUnlock() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setUniqueId("tier");
+        tier.setActivateOnUnlock(true);
+
+        GeneratorTierObject clone = tier.clone();
+        assertTrue(clone.isActivateOnUnlock());
     }
 }

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -550,6 +550,74 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
                 "stone-generator.conversations.prefixstone-generator.messages.generator-cannot-be-unlocked");
     }
 
+    /**
+     * Prepares generatorTier and island for unlock/auto-activation tests and returns a fresh, real data object.
+     */
+    private GeneratorDataObject prepareUnlockableGenerator() {
+        when(generatorTier.isDeployed()).thenReturn(true);
+        when(generatorTier.isDefaultGenerator()).thenReturn(false);
+        when(island.getUniqueId()).thenReturn("island-106");
+        s.setNotifyUnlockedGenerators(false);
+
+        GeneratorDataObject data = new GeneratorDataObject();
+        data.setUniqueId("island-106");
+        return data;
+    }
+
+    @Test
+    void testUnlockGeneratorAutoActivatesWhenFlagSet() {
+        GeneratorDataObject data = prepareUnlockableGenerator();
+        when(generatorTier.isActivateOnUnlock()).thenReturn(true);
+
+        sgm.unlockGenerator(data, user, island, generatorTier);
+
+        assertTrue(data.getUnlockedTiers().contains(uuid.toString()));
+        assertTrue(data.getActiveGeneratorList().contains(uuid.toString()));
+    }
+
+    @Test
+    void testUnlockGeneratorDoesNotAutoActivateWhenFlagUnset() {
+        GeneratorDataObject data = prepareUnlockableGenerator();
+        when(generatorTier.isActivateOnUnlock()).thenReturn(false);
+
+        sgm.unlockGenerator(data, user, island, generatorTier);
+
+        assertTrue(data.getUnlockedTiers().contains(uuid.toString()));
+        assertFalse(data.getActiveGeneratorList().contains(uuid.toString()));
+    }
+
+    @Test
+    void testAutoActivateRespectsLimitWithoutOverwrite() {
+        GeneratorDataObject data = prepareUnlockableGenerator();
+        when(generatorTier.isActivateOnUnlock()).thenReturn(true);
+        // One active generator already, limit of one, overwrite disabled.
+        data.setIslandActiveGeneratorCount(1);
+        data.getActiveGeneratorList().add("existing");
+        s.setOverwriteOnActive(false);
+
+        sgm.unlockGenerator(data, user, island, generatorTier);
+
+        // Unlocked, but not activated because the active limit is reached.
+        assertTrue(data.getUnlockedTiers().contains(uuid.toString()));
+        assertFalse(data.getActiveGeneratorList().contains(uuid.toString()));
+        assertTrue(data.getActiveGeneratorList().contains("existing"));
+    }
+
+    @Test
+    void testAutoActivateOverwritesWhenLimitReached() {
+        GeneratorDataObject data = prepareUnlockableGenerator();
+        when(generatorTier.isActivateOnUnlock()).thenReturn(true);
+        data.setIslandActiveGeneratorCount(1);
+        data.getActiveGeneratorList().add("existing");
+        s.setOverwriteOnActive(true);
+
+        sgm.unlockGenerator(data, user, island, generatorTier);
+
+        // The old generator is replaced by the newly unlocked one.
+        assertFalse(data.getActiveGeneratorList().contains("existing"));
+        assertTrue(data.getActiveGeneratorList().contains(uuid.toString()));
+    }
+
     @Test
     void testDeactivateGenerator() {
         assertFalse(sgm.deactivateGenerator(user, generatorData, generatorTier));

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -619,6 +619,32 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
     }
 
     @Test
+    void testAutoActivateCancelledEventKeepsExistingActiveGenerator() {
+        GeneratorDataObject data = prepareUnlockableGenerator();
+        when(generatorTier.isActivateOnUnlock()).thenReturn(true);
+        data.setIslandActiveGeneratorCount(1);
+        data.getActiveGeneratorList().add("existing");
+        s.setOverwriteOnActive(true);
+
+        // Cancel any activation event.
+        Mockito.doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof world.bentobox.magiccobblestonegenerator.events.GeneratorActivationEvent activation) {
+                activation.setCancelled(true);
+            }
+            return null;
+        }).when(pim).callEvent(any(
+                world.bentobox.magiccobblestonegenerator.events.GeneratorActivationEvent.class));
+
+        sgm.unlockGenerator(data, user, island, generatorTier);
+
+        // Activation was cancelled before mutating: the existing generator is preserved, the new one is not added.
+        assertTrue(data.getUnlockedTiers().contains(uuid.toString()));
+        assertTrue(data.getActiveGeneratorList().contains("existing"));
+        assertFalse(data.getActiveGeneratorList().contains(uuid.toString()));
+    }
+
+    @Test
     void testDeactivateGenerator() {
         assertFalse(sgm.deactivateGenerator(user, generatorData, generatorTier));
     }


### PR DESCRIPTION
Closes #106

## Feature
Generators can be flagged to **activate automatically as soon as they are unlocked**. This makes it easy to manage progressive generator tiers via bundles without depending on default generators (which run even when not in a bundle).

## Change
- **Data model:** `GeneratorTierObject.activateOnUnlock` boolean (`@Expose`, cloned). Defaults to `false`, so existing generators are unaffected.
- **Logic:** `unlockGenerator` auto-activates the generator when the flag is set, through a new `autoActivateGenerator` helper that:
  - works without a user (system-triggered unlocks pass `null`),
  - respects the island's active-generator limit and the `overwrite-on-activate` setting (replaces the oldest when overwrite is on, otherwise leaves it unlocked-but-inactive when full),
  - fires `GeneratorActivationEvent` (cancellable),
  - bypasses activation/purchase cost, since it's a config-driven automatic action,
  - skips the now-irrelevant click-to-activate notification.
- **Admin GUI:** an `ACTIVATE_ON_UNLOCK` toggle button in the generator edit panel (slot 29), with new en-US locale strings.

## Tests
- `StoneGeneratorManagerTest`: auto-activates when flag set; does not when unset; respects limit without overwrite; overwrites oldest when limit reached and overwrite enabled.
- `GeneratorTierObjectTest`: field default, accessor, clone copy.

Full suite: 95 tests pass.

> Note: this branch adds `GeneratorTierObjectTest`, as does #158 (#88). Whichever merges second will hit a trivial add/add conflict on that file (just keep both classes' methods) — happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)