### PR TITLE
Add admin command to reset a player's generator data (#149)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
@@ -94,56 +94,72 @@ public class GeneratorAdminCommand extends CompositeCommand
 
 
     // ---------------------------------------------------------------------
-    // Section: Shared helpers
+    // Section: Subcommands
     // ---------------------------------------------------------------------
 
 
     /**
-     * Shared tab-completer for subcommands that take a single player name argument. Online player names are only
-     * suggested once at least one character has been typed.
-     *
-     * @param user the user completing the command.
-     * @param args the current command arguments.
-     * @return the list of matching online player names.
+     * Base class for admin subcommands that take a single player name argument. It validates the argument, resolves the
+     * target player UUID and provides player name tab-completion, delegating the actual work to
+     * {@link #executeForTarget(User, String, UUID)}.
      */
-    private static Optional<List<String>> playerTabComplete(User user, List<String> args)
+    private abstract static class PlayerTargetCommand extends ConfirmableCommand
     {
-        if (args.isEmpty())
+        protected PlayerTargetCommand(StoneGeneratorAddon addon, CompositeCommand parentCommand, String label)
         {
-            // Don't show every player on the server. Require at least the first letter
-            return Optional.empty();
+            super(addon, parentCommand, label);
         }
 
-        return Optional.of(Util.tabLimit(
-            new ArrayList<>(Util.getOnlinePlayerList(user)),
-            args.get(args.size() - 1)));
-    }
 
-
-    /**
-     * Resolves the target player UUID from the given name and messages the user if it cannot be resolved.
-     *
-     * @param user the user running the command.
-     * @param name the player name argument.
-     * @return the resolved UUID, or null if it could not be resolved.
-     */
-    private static UUID resolveTargetUUID(User user, String name)
-    {
-        UUID targetUUID = Util.getUUID(name);
-
-        if (targetUUID == null)
+        @Override
+        public boolean execute(User user, String label, List<String> args)
         {
-            Utils.sendMessage(user,
-                user.getTranslation("general.errors.unknown-player", TextVariables.NAME, name));
+            // If args are not right, show help
+            if (args.size() != 1)
+            {
+                this.showHelp(this, user);
+                return false;
+            }
+
+            // Get target
+            UUID targetUUID = Util.getUUID(args.get(0));
+
+            if (targetUUID == null)
+            {
+                Utils.sendMessage(user,
+                    user.getTranslation("general.errors.unknown-player", TextVariables.NAME, args.get(0)));
+                return false;
+            }
+
+            return this.executeForTarget(user, args.get(0), targetUUID);
         }
 
-        return targetUUID;
+
+        /**
+         * Runs the subcommand for the resolved target player.
+         *
+         * @param user the user running the command.
+         * @param targetName the player name argument as typed.
+         * @param targetUUID the resolved target player UUID.
+         * @return {@code true} if the command executed successfully.
+         */
+        protected abstract boolean executeForTarget(User user, String targetName, UUID targetUUID);
+
+
+        @Override
+        public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
+        {
+            if (args.isEmpty())
+            {
+                // Don't show every player on the server. Require at least the first letter
+                return Optional.empty();
+            }
+
+            return Optional.of(Util.tabLimit(
+                new ArrayList<>(Util.getOnlinePlayerList(user)),
+                args.get(args.size() - 1)));
+        }
     }
-
-
-    // ---------------------------------------------------------------------
-    // Section: Subcommadns
-    // ---------------------------------------------------------------------
 
 
     /**
@@ -213,7 +229,7 @@ public class GeneratorAdminCommand extends CompositeCommand
      * This is a debug command for admins. Admins could use to check which generator user is using and could faster find
      * an issue.
      */
-    private static class GeneratorWhyCommand extends ConfirmableCommand
+    private static class GeneratorWhyCommand extends PlayerTargetCommand
     {
         /**
          * This is simple constructor for initializing /{admin_command} why generator command.
@@ -227,17 +243,6 @@ public class GeneratorAdminCommand extends CompositeCommand
         }
 
 
-        /**
-         * Setups anything that is needed for this command. <br/><br/> It is recommended you do the following in this
-         * method:
-         * <ul>
-         * <li>Register any of the sub-commands of this command;</li>
-         * <li>Define the permission required to use this command using {@link
-         * CompositeCommand#setPermission(String)};</li>
-         * <li>Define whether this command can only be run by players or not using {@link
-         * CompositeCommand#setOnlyPlayer(boolean)};</li>
-         * </ul>
-         */
         @Override
         public void setup()
         {
@@ -249,33 +254,9 @@ public class GeneratorAdminCommand extends CompositeCommand
         }
 
 
-        /**
-         * Defines what will be executed when this command is run.
-         *
-         * @param user the {@link User} who is executing this command.
-         * @param label the label which has been used to execute this command. It can be {@link
-         * CompositeCommand#getLabel()} or an alias.
-         * @param args the command arguments.
-         * @return {@code true} if the command executed successfully, {@code false} otherwise.
-         */
         @Override
-        public boolean execute(User user, String label, List<String> args)
+        protected boolean executeForTarget(User user, String targetName, UUID targetUUID)
         {
-            // If args are not right, show help
-            if (args.size() != 1)
-            {
-                this.showHelp(this, user);
-                return false;
-            }
-
-            // Get target
-            UUID targetUUID = resolveTargetUUID(user, args.get(0));
-
-            if (targetUUID == null)
-            {
-                return false;
-            }
-
             // Set meta data on player
             Island island = this.getAddon().getIslands().getIsland(this.getWorld(), targetUUID);
 
@@ -327,22 +308,6 @@ public class GeneratorAdminCommand extends CompositeCommand
 
             return true;
         }
-
-
-        /**
-         * Tab Completer for CompositeCommands. Note that any registered sub-commands will be automatically added to the
-         * list. Use this to add tab-complete for things like names.
-         *
-         * @param user the {@link User} who is executing this command.
-         * @param alias alias for command
-         * @param args command arguments
-         * @return List of strings that could be used to complete this command.
-         */
-        @Override
-        public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
-        {
-            return playerTabComplete(user, args);
-        }
     }
 
 
@@ -350,7 +315,7 @@ public class GeneratorAdminCommand extends CompositeCommand
      * This command resets a single player's island generator data (unlocked, purchased and active generators) without
      * touching the rest of the database. Requires confirmation as it is destructive.
      */
-    private static class ResetCommand extends ConfirmableCommand
+    private static class ResetCommand extends PlayerTargetCommand
     {
         /**
          * This is simple constructor for initializing /{admin_command} generator reset command.
@@ -376,23 +341,8 @@ public class GeneratorAdminCommand extends CompositeCommand
 
 
         @Override
-        public boolean execute(User user, String label, List<String> args)
+        protected boolean executeForTarget(User user, String targetName, UUID targetUUID)
         {
-            // If args are not right, show help
-            if (args.size() != 1)
-            {
-                this.showHelp(this, user);
-                return false;
-            }
-
-            // Get target
-            UUID targetUUID = resolveTargetUUID(user, args.get(0));
-
-            if (targetUUID == null)
-            {
-                return false;
-            }
-
             Island island = this.getAddon().getIslands().getIsland(this.getWorld(), targetUUID);
 
             if (island == null)
@@ -403,28 +353,21 @@ public class GeneratorAdminCommand extends CompositeCommand
 
             // Fall back to the typed argument if the server cannot resolve a name for the UUID.
             final String resolvedName = this.getPlayers().getName(targetUUID);
-            final String targetName = resolvedName == null || resolvedName.isEmpty() ? args.get(0) : resolvedName;
+            final String displayName = resolvedName == null || resolvedName.isEmpty() ? targetName : resolvedName;
 
             this.askConfirmation(user,
                 user.getTranslation(Constants.CONVERSATIONS + "prefix") +
                     user.getTranslation(Constants.ADMIN_COMMANDS + "reset.confirmation",
-                        Constants.PLAYER, targetName),
+                        Constants.PLAYER, displayName),
                 () ->
                 {
                     this.<StoneGeneratorAddon>getAddon().getAddonManager().resetIslandData(island);
                     Utils.sendMessage(user,
                         user.getTranslation(Constants.MESSAGES + "generator-data-reset",
-                            Constants.PLAYER, targetName));
+                            Constants.PLAYER, displayName));
                 });
 
             return true;
-        }
-
-
-        @Override
-        public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
-        {
-            return playerTabComplete(user, args);
         }
     }
 }

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
@@ -112,6 +112,18 @@ public class GeneratorAdminCommand extends CompositeCommand
 
 
         @Override
+        public void setup()
+        {
+            // Permission and locale references are derived from the subcommand label.
+            this.setPermission("admin.stone-generator." + this.getLabel());
+            this.setParametersHelp(Constants.ADMIN_COMMANDS + this.getLabel() + ".parameters");
+            this.setDescription(Constants.ADMIN_COMMANDS + this.getLabel() + ".description");
+
+            this.setOnlyPlayer(false);
+        }
+
+
+        @Override
         public boolean execute(User user, String label, List<String> args)
         {
             // If args are not right, show help
@@ -244,17 +256,6 @@ public class GeneratorAdminCommand extends CompositeCommand
 
 
         @Override
-        public void setup()
-        {
-            this.setPermission("admin.stone-generator.why");
-            this.setParametersHelp(Constants.ADMIN_COMMANDS + "why.parameters");
-            this.setDescription(Constants.ADMIN_COMMANDS + "why.description");
-
-            this.setOnlyPlayer(false);
-        }
-
-
-        @Override
         protected boolean executeForTarget(User user, String targetName, UUID targetUUID)
         {
             // Set meta data on player
@@ -326,17 +327,6 @@ public class GeneratorAdminCommand extends CompositeCommand
         public ResetCommand(StoneGeneratorAddon addon, CompositeCommand parentCommand)
         {
             super(addon, parentCommand, "reset");
-        }
-
-
-        @Override
-        public void setup()
-        {
-            this.setPermission("admin.stone-generator.reset");
-            this.setParametersHelp(Constants.ADMIN_COMMANDS + "reset.parameters");
-            this.setDescription(Constants.ADMIN_COMMANDS + "reset.description");
-
-            this.setOnlyPlayer(false);
         }
 
 

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
@@ -94,6 +94,54 @@ public class GeneratorAdminCommand extends CompositeCommand
 
 
     // ---------------------------------------------------------------------
+    // Section: Shared helpers
+    // ---------------------------------------------------------------------
+
+
+    /**
+     * Shared tab-completer for subcommands that take a single player name argument. Online player names are only
+     * suggested once at least one character has been typed.
+     *
+     * @param user the user completing the command.
+     * @param args the current command arguments.
+     * @return the list of matching online player names.
+     */
+    private static Optional<List<String>> playerTabComplete(User user, List<String> args)
+    {
+        if (args.isEmpty())
+        {
+            // Don't show every player on the server. Require at least the first letter
+            return Optional.empty();
+        }
+
+        return Optional.of(Util.tabLimit(
+            new ArrayList<>(Util.getOnlinePlayerList(user)),
+            args.get(args.size() - 1)));
+    }
+
+
+    /**
+     * Resolves the target player UUID from the given name and messages the user if it cannot be resolved.
+     *
+     * @param user the user running the command.
+     * @param name the player name argument.
+     * @return the resolved UUID, or null if it could not be resolved.
+     */
+    private static UUID resolveTargetUUID(User user, String name)
+    {
+        UUID targetUUID = Util.getUUID(name);
+
+        if (targetUUID == null)
+        {
+            Utils.sendMessage(user,
+                user.getTranslation("general.errors.unknown-player", TextVariables.NAME, name));
+        }
+
+        return targetUUID;
+    }
+
+
+    // ---------------------------------------------------------------------
     // Section: Subcommadns
     // ---------------------------------------------------------------------
 
@@ -221,13 +269,10 @@ public class GeneratorAdminCommand extends CompositeCommand
             }
 
             // Get target
-            UUID targetUUID = Util.getUUID(args.get(0));
+            UUID targetUUID = resolveTargetUUID(user, args.get(0));
 
             if (targetUUID == null)
             {
-                Utils.sendMessage(user,
-                    user.getTranslation("general.errors.unknown-player",
-                        TextVariables.NAME, args.get(0)));
                 return false;
             }
 
@@ -296,17 +341,7 @@ public class GeneratorAdminCommand extends CompositeCommand
         @Override
         public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
         {
-            if (args.isEmpty())
-            {
-                // Don't show every player on the server. Require at least the first letter
-                return Optional.empty();
-            }
-            else
-            {
-                return Optional.of(Util.tabLimit(
-                    new ArrayList<>(Util.getOnlinePlayerList(user)),
-                    args.get(args.size() - 1)));
-            }
+            return playerTabComplete(user, args);
         }
     }
 
@@ -351,13 +386,10 @@ public class GeneratorAdminCommand extends CompositeCommand
             }
 
             // Get target
-            UUID targetUUID = Util.getUUID(args.get(0));
+            UUID targetUUID = resolveTargetUUID(user, args.get(0));
 
             if (targetUUID == null)
             {
-                Utils.sendMessage(user,
-                    user.getTranslation("general.errors.unknown-player",
-                        TextVariables.NAME, args.get(0)));
                 return false;
             }
 
@@ -369,7 +401,9 @@ public class GeneratorAdminCommand extends CompositeCommand
                 return false;
             }
 
-            final String targetName = this.getPlayers().getName(targetUUID);
+            // Fall back to the typed argument if the server cannot resolve a name for the UUID.
+            final String resolvedName = this.getPlayers().getName(targetUUID);
+            final String targetName = resolvedName == null || resolvedName.isEmpty() ? args.get(0) : resolvedName;
 
             this.askConfirmation(user,
                 user.getTranslation(Constants.CONVERSATIONS + "prefix") +
@@ -390,17 +424,7 @@ public class GeneratorAdminCommand extends CompositeCommand
         @Override
         public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
         {
-            if (args.isEmpty())
-            {
-                // Don't show every player on the server. Require at least the first letter
-                return Optional.empty();
-            }
-            else
-            {
-                return Optional.of(Util.tabLimit(
-                    new ArrayList<>(Util.getOnlinePlayerList(user)),
-                    args.get(args.size() - 1)));
-            }
+            return playerTabComplete(user, args);
         }
     }
 }

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommand.java
@@ -64,6 +64,7 @@ public class GeneratorAdminCommand extends CompositeCommand
         new ImportCommand(this.getAddon(), this);
         new GeneratorWhyCommand(this.getAddon(), this);
         new GeneratorDatabaseCommand(this.getAddon(), this);
+        new ResetCommand(this.getAddon(), this);
     }
 
 
@@ -292,6 +293,100 @@ public class GeneratorAdminCommand extends CompositeCommand
          * @param args command arguments
          * @return List of strings that could be used to complete this command.
          */
+        @Override
+        public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
+        {
+            if (args.isEmpty())
+            {
+                // Don't show every player on the server. Require at least the first letter
+                return Optional.empty();
+            }
+            else
+            {
+                return Optional.of(Util.tabLimit(
+                    new ArrayList<>(Util.getOnlinePlayerList(user)),
+                    args.get(args.size() - 1)));
+            }
+        }
+    }
+
+
+    /**
+     * This command resets a single player's island generator data (unlocked, purchased and active generators) without
+     * touching the rest of the database. Requires confirmation as it is destructive.
+     */
+    private static class ResetCommand extends ConfirmableCommand
+    {
+        /**
+         * This is simple constructor for initializing /{admin_command} generator reset command.
+         *
+         * @param addon StoneGeneratorAddon addon.
+         * @param parentCommand Parent Command where we hook our command into.
+         */
+        public ResetCommand(StoneGeneratorAddon addon, CompositeCommand parentCommand)
+        {
+            super(addon, parentCommand, "reset");
+        }
+
+
+        @Override
+        public void setup()
+        {
+            this.setPermission("admin.stone-generator.reset");
+            this.setParametersHelp(Constants.ADMIN_COMMANDS + "reset.parameters");
+            this.setDescription(Constants.ADMIN_COMMANDS + "reset.description");
+
+            this.setOnlyPlayer(false);
+        }
+
+
+        @Override
+        public boolean execute(User user, String label, List<String> args)
+        {
+            // If args are not right, show help
+            if (args.size() != 1)
+            {
+                this.showHelp(this, user);
+                return false;
+            }
+
+            // Get target
+            UUID targetUUID = Util.getUUID(args.get(0));
+
+            if (targetUUID == null)
+            {
+                Utils.sendMessage(user,
+                    user.getTranslation("general.errors.unknown-player",
+                        TextVariables.NAME, args.get(0)));
+                return false;
+            }
+
+            Island island = this.getAddon().getIslands().getIsland(this.getWorld(), targetUUID);
+
+            if (island == null)
+            {
+                Utils.sendMessage(user, user.getTranslation("general.errors.player-has-no-island"));
+                return false;
+            }
+
+            final String targetName = this.getPlayers().getName(targetUUID);
+
+            this.askConfirmation(user,
+                user.getTranslation(Constants.CONVERSATIONS + "prefix") +
+                    user.getTranslation(Constants.ADMIN_COMMANDS + "reset.confirmation",
+                        Constants.PLAYER, targetName),
+                () ->
+                {
+                    this.<StoneGeneratorAddon>getAddon().getAddonManager().resetIslandData(island);
+                    Utils.sendMessage(user,
+                        user.getTranslation(Constants.MESSAGES + "generator-data-reset",
+                            Constants.PLAYER, targetName));
+                });
+
+            return true;
+        }
+
+
         @Override
         public Optional<List<String>> tabComplete(User user, String alias, List<String> args)
         {

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -1448,6 +1448,18 @@ public class StoneGeneratorManager {
 	this.wipeGeneratorData(dataObject.getUniqueId());
     }
 
+    /**
+     * This method resets all generator data for the given island: its stored data is removed and a fresh default data
+     * object is recreated. Unlocked, purchased and active generators are cleared (#149).
+     *
+     * @param island Island whose generator data must be reset.
+     */
+    public void resetIslandData(@NotNull Island island) {
+	this.wipeGeneratorData(island.getUniqueId());
+	// Recreate a fresh, default data object so the island keeps working immediately.
+	this.validateIslandData(island);
+    }
+
     // ---------------------------------------------------------------------
     // Section: Methods
     // ---------------------------------------------------------------------

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -1456,8 +1456,14 @@ public class StoneGeneratorManager {
      */
     public void resetIslandData(@NotNull Island island) {
 	this.wipeGeneratorData(island.getUniqueId());
-	// Recreate a fresh, default data object so the island keeps working immediately.
-	this.validateIslandData(island);
+	// Recreate a fresh, default data object so the island keeps working immediately. addIslandData works even
+	// for ownerless islands (e.g. spawn), unlike validateIslandData which returns early when there is no owner.
+	this.addIslandData(island);
+
+	if (island.getOwner() != null) {
+	    // For owned islands, also re-apply owner bundles/limits and re-evaluate unlocks.
+	    this.validateIslandData(island);
+	}
     }
 
     // ---------------------------------------------------------------------

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -11,6 +11,10 @@ stone-generator:
       why:
         parameters: "<player>"
         description: "toggles Magic Cobblestone Generator debug messages"
+      reset:
+        parameters: "<player>"
+        description: "resets a player's island generator data"
+        confirmation: "This will reset [player]'s generator data (unlocked, purchased and active generators) - please confirm"
       database:
         description: "Main database command"
       import-database:
@@ -999,6 +1003,8 @@ stone-generator:
     generator-exhausted: "<red>Generator </red> '[generator]' <red>has reached its generation limit and is now on cooldown for [number] more minute(s).</red>"
     # Message that appears when purchasing the generator.
     generator-purchased: "<yellow>Generator </yellow> '[generator]' <yellow>is purchased.</yellow>"
+    # Message that appears after an admin resets a player's generator data.
+    generator-data-reset: "<yellow>Generator data for </yellow>[player]<yellow> has been reset.</yellow>"
     # Message that appears when trying to buy already purchased generator.
     generator-already-purchased: "<red>Generator </red> '[generator]' <red>is already purchased.</red>"
     # Message that appears when trying to buy generator without required island level

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommandTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/commands/admin/GeneratorAdminCommandTest.java
@@ -41,6 +41,7 @@ class GeneratorAdminCommandTest extends CommonTestSetup {
     private Settings settings;
     private CompositeCommand ic;
     private CompositeCommand why;
+    private CompositeCommand reset;
 
     @Override
     @BeforeEach
@@ -78,6 +79,7 @@ class GeneratorAdminCommandTest extends CommonTestSetup {
         gac = new GeneratorAdminCommand(addon, ac);
         ic = gac.getSubCommand("import").get();
         why = gac.getSubCommand("why").get();
+        reset = gac.getSubCommand("reset").get();
     }
 
     @Test
@@ -130,7 +132,7 @@ class GeneratorAdminCommandTest extends CommonTestSetup {
                 "stone-generator.commands.admin.main.parameters");
         verify(user).getTranslation(
                 "stone-generator.commands.admin.main.description");
-        verify(user, times(4)).isPlayer();
+        verify(user, times(5)).isPlayer();
         verify(user).sendMessage(
                 "commands.help.syntax-no-parameters",
                 "[usage]",
@@ -156,6 +158,12 @@ class GeneratorAdminCommandTest extends CommonTestSetup {
                 "[description]",
                 "stone-generator.commands.admin.database.description");
         verify(user).sendMessage(
+                "commands.help.syntax-no-parameters",
+                "[usage]",
+                "/null generator reset",
+                "[description]",
+                "stone-generator.commands.admin.reset.description");
+        verify(user).sendMessage(
                 "commands.help.end");
     }
 
@@ -179,6 +187,37 @@ class GeneratorAdminCommandTest extends CommonTestSetup {
         assertFalse(why.execute(user, "bskyblock", List.of("tastybento")));
         verify(user).sendMessage(
                 "stone-generator.conversations.prefixgeneral.errors.player-is-not-owner");
+    }
+
+    @Test
+    void testSetupReset() {
+        assertEquals("admin.stone-generator.reset", reset.getPermission());
+        assertEquals("stone-generator.commands.admin.reset.parameters", reset.getParameters());
+        assertEquals("stone-generator.commands.admin.reset.description", reset.getDescription());
+        assertFalse(reset.isOnlyPlayer());
+    }
+
+    @Test
+    void testExecuteResetNoArgs() {
+        assertFalse(reset.execute(user, "bskyblock", List.of()));
+        verify(user).sendMessage(
+                "commands.help.header",
+                "[label]",
+                "BSkyBlock World");
+        verify(user).getTranslationOrNothing(
+                "stone-generator.commands.admin.reset.parameters");
+        verify(user).getTranslation(
+                "stone-generator.commands.admin.reset.description");
+        verify(user).sendMessage(
+                "commands.help.end");
+    }
+
+    @Test
+    void testExecuteResetPlayerNoIsland() {
+        // Target resolves to a UUID but has no island in this world.
+        assertFalse(reset.execute(user, "bskyblock", List.of("tastybento")));
+        verify(user).sendMessage(
+                "stone-generator.conversations.prefixgeneral.errors.player-has-no-island");
     }
 
 }

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -711,6 +711,14 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
     }
 
     @Test
+    void testResetIslandData() {
+        when(island.getUniqueId()).thenReturn("island-149");
+        assertDoesNotThrow(() -> sgm.resetIslandData(island));
+        // The island's stored data is deleted as part of the reset.
+        verify(h).deleteID("island-149");
+    }
+
+    @Test
     void testWipeGeneratorDataGeneratorDataObject() {
         assertDoesNotThrow(() -> sgm.wipeGeneratorData(generatorData));
     }


### PR DESCRIPTION
Closes #149

## Feature
Adds `/{admin} generator reset <player>` — a way for admins to reset a single player's island generator data (unlocked, purchased and active generators) **without** wiping the whole database or deleting files.

## Change
- **Manager:** `StoneGeneratorManager.resetIslandData(island)` removes the island's stored data and immediately recreates a fresh default data object, so the island keeps working (default generators re-applied, permission unlocks re-evaluated).
- **Command:** a new confirmable `ResetCommand` subcommand of `GeneratorAdminCommand`:
  - permission `admin.stone-generator.reset`
  - resolves the target player, checks they have an island in this world
  - asks for confirmation (it's destructive), then resets and reports success
  - player-name tab-completion
- **Locale:** new `commands.admin.reset` entries (parameters/description/confirmation) and a `generator-data-reset` success message.

## Tests
- `StoneGeneratorManagerTest.testResetIslandData` — reset deletes the island's stored data.
- `GeneratorAdminCommandTest`: setup (permission/params/description), no-args → help, and target-with-no-island → error. Updated the help-listing test for the new subcommand.

Full suite: 106 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)