### PR TITLE
Add option to lose level-gated tiers when island level drops (#118)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/config/Settings.java
@@ -329,6 +329,28 @@ public class Settings implements ConfigObject
 
 
     /**
+     * Is lose tiers on level loss boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isLoseTiersOnLevelLoss()
+    {
+        return loseTiersOnLevelLoss;
+    }
+
+
+    /**
+     * Sets lose tiers on level loss.
+     *
+     * @param loseTiersOnLevelLoss the lose tiers on level loss
+     */
+    public void setLoseTiersOnLevelLoss(boolean loseTiersOnLevelLoss)
+    {
+        this.loseTiersOnLevelLoss = loseTiersOnLevelLoss;
+    }
+
+
+    /**
      * Is use bank account boolean.
      *
      * @return the boolean
@@ -513,6 +535,13 @@ public class Settings implements ConfigObject
     @ConfigComment("The confirmation is requested via a chat prompt.")
     @ConfigEntry(path = "buy-confirmation")
     private boolean buyConfirmation = true;
+
+    @ConfigComment("")
+    @ConfigComment("If enabled, generators unlocked purely by reaching an island level are locked again")
+    @ConfigComment("when the island level drops back below their required level. Purchased generators are")
+    @ConfigComment("always kept. Requires the Level addon.")
+    @ConfigEntry(path = "lose-tiers-on-level-loss")
+    private boolean loseTiersOnLevelLoss = false;
 
     @ConfigComment("")
     @ConfigComment("Send a notification message when player unlocks a new generator.")

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -883,6 +883,46 @@ public class StoneGeneratorManager {
 	// Revoke permission based generators that the current owner no longer qualifies for.
 	// This handles ownership transfer to a player without the required permission (#133).
 	this.revokePermissionGenerators(island, dataObject, owner);
+
+	// Revoke level based generators when the island level dropped below their requirement (#118).
+	this.revokeLevelLockedGenerators(island, dataObject, islandLevel);
+    }
+
+    /**
+     * This method locks level based generators again when the island level has dropped below their required level. It
+     * only runs when the {@code lose-tiers-on-level-loss} setting is enabled, and never revokes purchased generators, so
+     * paid tiers are kept even if the level drops (#118).
+     *
+     * @param island      Island which is targeted for the check.
+     * @param dataObject  Data object that stores island generators.
+     * @param islandLevel The current island level.
+     */
+    private void revokeLevelLockedGenerators(@NotNull Island island, @NotNull GeneratorDataObject dataObject,
+	    long islandLevel) {
+	if (!this.addon.getSettings().isLoseTiersOnLevelLoss()) {
+	    // Feature disabled: unlocked generators stay unlocked regardless of level.
+	    return;
+	}
+
+	List<GeneratorTierObject> revokeList = this.getIslandGeneratorTiers(island.getWorld(), dataObject).stream()
+		// Only level gated generators can be revoked this way.
+		.filter(generator -> generator.getRequiredMinIslandLevel() > 0)
+		// Whose required level is now above the current island level.
+		.filter(generator -> generator.getRequiredMinIslandLevel() > islandLevel)
+		// That are currently unlocked.
+		.filter(generator -> dataObject.getUnlockedTiers().contains(generator.getUniqueId()))
+		// But that were not purchased. Paid tiers are kept even when the level drops.
+		.filter(generator -> !dataObject.getPurchasedTiers().contains(generator.getUniqueId()))
+		.collect(Collectors.toList());
+
+	if (!revokeList.isEmpty()) {
+	    revokeList.forEach(generator -> {
+		dataObject.getUnlockedTiers().remove(generator.getUniqueId());
+		dataObject.getActiveGeneratorList().remove(generator.getUniqueId());
+	    });
+
+	    this.saveGeneratorData(dataObject);
+	}
     }
 
     /**

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -431,6 +431,76 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
     }
 
     /**
+     * Seeds a deployed, level-gated (required level 100) generator that is already unlocked and active, for
+     * lose-tiers-on-level-loss tests (#118).
+     */
+    private GeneratorDataObject seedLevelGeneratorAndData() {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-118");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+
+        when(generatorTier.getUniqueId()).thenReturn("magiccobblegenerator_level");
+        when(generatorTier.isDeployed()).thenReturn(true);
+        when(generatorTier.isDefaultGenerator()).thenReturn(false);
+        when(generatorTier.getGeneratorType()).thenReturn(GeneratorType.COBBLESTONE);
+        when(generatorTier.getRequiredMinIslandLevel()).thenReturn(100L);
+        when(generatorTier.getRequiredPermissions()).thenReturn(java.util.Collections.emptySet());
+        sgm.loadGeneratorTier(generatorTier, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+        data.getUnlockedTiers().add("magiccobblegenerator_level");
+        data.getActiveGeneratorList().add("magiccobblegenerator_level");
+        return data;
+    }
+
+    @Test
+    void testRevokesLevelGeneratorWhenLevelDropped() {
+        GeneratorDataObject data = seedLevelGeneratorAndData();
+        s.setLoseTiersOnLevelLoss(true);
+
+        // Island level dropped to 10, below the generator's required level of 100.
+        sgm.checkGeneratorUnlockStatus(island, null, 10L);
+
+        assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_level"));
+        assertFalse(data.getActiveGeneratorList().contains("magiccobblegenerator_level"));
+    }
+
+    @Test
+    void testKeepsPurchasedLevelGeneratorWhenLevelDropped() {
+        GeneratorDataObject data = seedLevelGeneratorAndData();
+        data.getPurchasedTiers().add("magiccobblegenerator_level");
+        s.setLoseTiersOnLevelLoss(true);
+
+        sgm.checkGeneratorUnlockStatus(island, null, 10L);
+
+        // Purchased tiers are kept even when the level drops.
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_level"));
+    }
+
+    @Test
+    void testDoesNotRevokeLevelGeneratorWhenFeatureDisabled() {
+        GeneratorDataObject data = seedLevelGeneratorAndData();
+        // Feature is off by default.
+
+        sgm.checkGeneratorUnlockStatus(island, null, 10L);
+
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_level"));
+    }
+
+    @Test
+    void testKeepsLevelGeneratorWhenLevelSufficient() {
+        GeneratorDataObject data = seedLevelGeneratorAndData();
+        s.setLoseTiersOnLevelLoss(true);
+
+        // Island level is still at or above the requirement.
+        sgm.checkGeneratorUnlockStatus(island, null, 200L);
+
+        assertTrue(data.getUnlockedTiers().contains("magiccobblegenerator_level"));
+    }
+
+    /**
      * Builds a deployed, non-default cobblestone generator tier mock with no permission/level requirements, for
      * prerequisite-generator tests.
      */


### PR DESCRIPTION
Closes #118

## Feature
Restores the pre-2.0.0 behaviour where a generator unlocked by island level is locked again if the island level later drops below its requirement. Off by default, behind a config toggle.

## Change
- **Setting:** `lose-tiers-on-level-loss` (`Settings.loseTiersOnLevelLoss`, default **false**). Requires the Level addon to be meaningful.
- **Logic:** `checkGeneratorUnlockStatus` now calls a new `revokeLevelLockedGenerators` after the existing permission revocation. When the feature is enabled, it removes from the island's unlocked + active lists any generator whose `requiredMinIslandLevel` is now **above** the current island level. This runs on the existing `IslandLevelCalculatedEvent → checkGeneratorUnlockStatus` path (see `IslandLevelListener`), so it triggers whenever the level is recalculated.

### Design choice
**Purchased tiers are always kept** — the revocation skips anything in `purchasedTiers`, so players never lose a generator they actually paid for. Only free, level-unlocked tiers are re-locked. (Mirrors how #133 preserves purchases for permission revocation.)

## Tests
Added to `StoneGeneratorManagerTest`:
- revokes a level-gated tier when the level drops below its requirement,
- keeps it when it was purchased,
- keeps it when the feature is disabled (default),
- keeps it when the level is still sufficient.

Full suite: 110 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)