### PR TITLE
Add AOneBlock phase requirement for generators (#121)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <bentobox.version>3.14.0-SNAPSHOT</bentobox.version>
         <level.version>2.5.0</level.version>
         <bank.version>1.4.0</bank.version>
+        <aoneblock.version>1.18.0</aoneblock.version>
         <!-- Test dependency versions -->
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.11.0</mockito.version>
@@ -149,6 +150,12 @@
             <groupId>world.bentobox</groupId>
             <artifactId>bank</artifactId>
             <version>${bank.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>world.bentobox</groupId>
+            <artifactId>aoneblock</artifactId>
+            <version>${aoneblock.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -230,6 +230,29 @@ public class GeneratorTierObject implements DataObject
 
 
     /**
+     * Method GeneratorTierObject#getRequiredPhase returns the AOneBlock phase that must be reached before this
+     * generator becomes available.
+     *
+     * @return the requiredPhase (type String) of this object, or an empty string if none.
+     */
+    public String getRequiredPhase()
+    {
+        return requiredPhase == null ? "" : requiredPhase;
+    }
+
+
+    /**
+     * Method GeneratorTierObject#setRequiredPhase sets new value for the requiredPhase of this object.
+     *
+     * @param requiredPhase new value for this object.
+     */
+    public void setRequiredPhase(String requiredPhase)
+    {
+        this.requiredPhase = requiredPhase == null ? "" : requiredPhase;
+    }
+
+
+    /**
      * Method GeneratorTierObject#getGeneratorTierCost returns the generatorTierCost of this object.
      *
      * @return the generatorTierCost (type double) of this object.
@@ -572,6 +595,7 @@ public class GeneratorTierObject implements DataObject
         clone.setRequiredBiomes(new HashSet<>(this.requiredBiomes));
         clone.setRequiredPermissions(new HashSet<>(this.requiredPermissions));
         clone.setRequiredGeneratorTiers(new HashSet<>(this.getRequiredGeneratorTiers()));
+        clone.setRequiredPhase(this.requiredPhase);
         clone.setGeneratorTierCost(this.generatorTierCost);
         clone.setActivationCost(this.activationCost);
         clone.setDeployed(this.deployed);
@@ -724,6 +748,12 @@ public class GeneratorTierObject implements DataObject
      */
     @Expose
     private Set<String> requiredGeneratorTiers = Collections.emptySet();
+
+    /**
+     * AOneBlock phase that must be reached before this generator becomes available. Empty means no phase requirement.
+     */
+    @Expose
+    private String requiredPhase = "";
 
     /**
      * Cost to do buy current generator.

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -32,6 +32,7 @@ import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
 import world.bentobox.bank.data.Money;
 import world.bentobox.bank.data.TxType;
+import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -877,6 +878,9 @@ public class StoneGeneratorManager {
 		// is unlocked earlier in this same pass and is visible here.
 		filter(generator -> dataObject.getUnlockedTiers().containsAll(generator.getRequiredGeneratorTiers()))
 		.
+		// Filter out generators whose required AOneBlock phase has not been reached yet (#121).
+		filter(generator -> this.isPhaseRequirementMet(island, generator))
+		.
 		// Now process each generator.
 		forEach(generator -> this.unlockGenerator(dataObject, user, island, generator));
 
@@ -1504,6 +1508,36 @@ public class StoneGeneratorManager {
 	}
 
 	return false;
+    }
+
+    /**
+     * This method returns whether the given generator's AOneBlock phase requirement is met for the given island. A
+     * generator with no required phase is always considered met. Otherwise the island's world must be an AOneBlock world
+     * and the island must have reached (block count) the required phase's starting block (#121).
+     *
+     * @param island    the island.
+     * @param generator the generator tier to check.
+     * @return {@code true} if the phase requirement is met.
+     */
+    private boolean isPhaseRequirementMet(@NotNull Island island, @NotNull GeneratorTierObject generator) {
+	final String requiredPhase = generator.getRequiredPhase();
+
+	if (requiredPhase == null || requiredPhase.isEmpty()) {
+	    // No phase requirement.
+	    return true;
+	}
+
+	Optional<GameModeAddon> gameMode = this.addon.getPlugin().getIWM().getAddon(island.getWorld());
+
+	if (gameMode.isEmpty() || !(gameMode.get() instanceof AOneBlock aoneBlock)) {
+	    // Phase requirements only apply to AOneBlock worlds.
+	    return false;
+	}
+
+	// The requirement is met once the island's block count has reached the required phase's starting block.
+	return aoneBlock.getOneBlockManager().getPhase(requiredPhase)
+		.map(phase -> aoneBlock.getOneBlocksIsland(island).getBlockNumber() >= phase.getBlockNumberValue())
+		.orElse(false);
     }
 
     /**

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
@@ -535,6 +535,18 @@ public abstract class CommonPanel
             level = "";
         }
 
+        String phase;
+
+        if (!generator.getRequiredPhase().isEmpty() && !isUnlocked)
+        {
+            phase = this.user.getTranslationOrNothing(reference + "phase",
+                TextVariables.NAME, generator.getRequiredPhase());
+        }
+        else
+        {
+            phase = "";
+        }
+
         StringBuilder permissions = new StringBuilder();
 
         if (!generator.getRequiredPermissions().isEmpty() && !isUnlocked)
@@ -602,6 +614,7 @@ public abstract class CommonPanel
         return this.user.getTranslationOrNothing(reference + "description",
             "[biomes]", biomes.toString(),
             "[level]", level,
+            "[phase]", phase,
             "[missing-permissions]", permissions.toString(),
             "[required-generators]", requiredGenerators.toString());
     }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -921,10 +921,13 @@ stone-generator:
           description: |-
             [biomes]
             [level]
+            [phase]
             [required-generators]
             [missing-permissions]
           # Generates [level] message.
           level: "<red><bold>Required Level: </bold></red><red>[number]</red>"
+          # Generates [phase] message (AOneBlock only).
+          phase: "<red><bold>Required Phase: </bold></red><red>[name]</red>"
           # Generates [required-generators] message title.
           required-generators-title: "<red><bold>Required Generators:</bold></red>"
           # Generates [required-generators] message values.

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
@@ -12,9 +12,38 @@ import org.junit.jupiter.api.Test;
 import world.bentobox.magiccobblestonegenerator.CommonTestSetup;
 
 /**
- * Tests for the requiredGeneratorTiers (#88) and activateOnUnlock (#106) fields of {@link GeneratorTierObject}.
+ * Tests for the requiredGeneratorTiers (#88), activateOnUnlock (#106) and requiredPhase (#121) fields of
+ * {@link GeneratorTierObject}.
  */
 class GeneratorTierObjectTest extends CommonTestSetup {
+
+    @Test
+    void testRequiredPhaseDefaultsToEmpty() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        assertTrue(tier.getRequiredPhase().isEmpty());
+    }
+
+    @Test
+    void testSetAndGetRequiredPhase() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setRequiredPhase("Underground");
+        assertEquals("Underground", tier.getRequiredPhase());
+    }
+
+    @Test
+    void testSetRequiredPhaseNullNormalizedToEmpty() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setRequiredPhase(null);
+        assertTrue(tier.getRequiredPhase().isEmpty());
+    }
+
+    @Test
+    void testCloneCopiesRequiredPhase() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setUniqueId("tier");
+        tier.setRequiredPhase("Underground");
+        assertEquals("Underground", tier.clone().getRequiredPhase());
+    }
 
     @Test
     void testRequiredGeneratorTiersDefaultsToEmpty() {

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -27,6 +27,10 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
+import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
+import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
 import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
@@ -499,6 +503,73 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
         // Gen1 stays locked, so Gen2's prerequisite is unmet and it stays locked too.
         assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_gen1"));
         assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_gen2"));
+    }
+
+    /**
+     * Sets up an AOneBlock world whose island has reached the given block count, plus a phase "Underground" that starts
+     * at block 100, and a phase-gated generator. Returns the island's data object (#121).
+     */
+    private GeneratorDataObject seedPhaseGenerator(String tierId, int islandBlockCount, boolean aOneBlockWorld) {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-121");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+        s.setNotifyUnlockedGenerators(false);
+
+        if (aOneBlockWorld) {
+            AOneBlock aoneBlock = mock(AOneBlock.class);
+            when(aoneBlock.getDescription()).thenReturn(
+                    new AddonDescription.Builder("", "AOneBlock", "1.0").build());
+            OneBlockPhase phase = mock(OneBlockPhase.class);
+            when(phase.getBlockNumberValue()).thenReturn(100);
+            OneBlocksManager obManager = mock(OneBlocksManager.class);
+            when(obManager.getPhase("Underground")).thenReturn(Optional.of(phase));
+            when(aoneBlock.getOneBlockManager()).thenReturn(obManager);
+            OneBlockIslands obIsland = mock(OneBlockIslands.class);
+            when(obIsland.getBlockNumber()).thenReturn(islandBlockCount);
+            when(aoneBlock.getOneBlocksIsland(island)).thenReturn(obIsland);
+            when(iwm.getAddon(world)).thenReturn(Optional.of(aoneBlock));
+        }
+        // Otherwise the default (non-AOneBlock) game mode from CommonTestSetup is used.
+
+        GeneratorTierObject tier = prerequisiteTier(tierId, "Phase Gen", 10);
+        when(tier.getRequiredPhase()).thenReturn("Underground");
+        sgm.loadGeneratorTier(tier, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+        return data;
+    }
+
+    @Test
+    void testUnlocksPhaseGeneratorWhenPhaseReached() {
+        // Island at block 150, past the phase's start block of 100.
+        GeneratorDataObject data = seedPhaseGenerator("aoneblock_phasegen", 150, true);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertTrue(data.getUnlockedTiers().contains("aoneblock_phasegen"));
+    }
+
+    @Test
+    void testKeepsPhaseGeneratorLockedWhenPhaseNotReached() {
+        // Island at block 50, before the phase's start block of 100.
+        GeneratorDataObject data = seedPhaseGenerator("aoneblock_phasegen", 50, true);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertFalse(data.getUnlockedTiers().contains("aoneblock_phasegen"));
+    }
+
+    @Test
+    void testKeepsPhaseGeneratorLockedInNonAOneBlockWorld() {
+        // Not an AOneBlock world: the phase requirement can never be satisfied. The tier id matches the default
+        // game mode so it is still evaluated.
+        GeneratorDataObject data = seedPhaseGenerator("magiccobblegenerator_phasegen", 150, false);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_phasegen"));
     }
 
     @Test


### PR DESCRIPTION
Closes #121

## Feature
Generators can now require an **AOneBlock phase** to be reached before they unlock, so OneBlock servers can gate generators behind progression (the ask in #121). This is the phase-only subset of #117.

## Change
- **Dependency:** adds `world.bentobox:aoneblock` as a `provided`-scope dependency, mirroring how Level/Bank are integrated.
- **Data model:** `GeneratorTierObject.requiredPhase` (String, `@Expose`, cloned, empty by default, null-normalised).
- **Enforcement:** `checkGeneratorUnlockStatus` gains a phase filter. A phase-gated generator unlocks once the island's **block count has reached** the required phase's starting block:
  ```
  island.getBlockNumber() >= getOneBlockManager().getPhase(requiredPhase).getBlockNumberValue()
  ```
  Because unlocks are permanent, it stays unlocked as the player progresses further. Non-AOneBlock worlds never satisfy a phase requirement (the phase filter returns false), so a stray phase requirement in a non-OB world simply keeps the generator locked (and visible in the lore).
- **Display:** requirements lore shows a `Required Phase` line (`[phase]`), with new en-US locale strings. Phase-name matching is case/space-insensitive (AOneBlock's `getPhase`).

## Tests
- `GeneratorTierObjectTest`: `requiredPhase` default/set/get/null-normalise/clone.
- `StoneGeneratorManagerTest` (mocking AOneBlock): unlocks when the phase is reached; stays locked when not reached; stays locked in a non-AOneBlock world.

Full suite: 113 tests pass.

## Scope note
`requiredPhase` is configurable via generator **export/import JSON** for now. An admin GUI editor is a sensible follow-up — the generator edit panel is currently at capacity (all inner slots used after #88/#106), so adding a button needs a small layout change I kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)