### PR TITLE
Add OneBlock block-count requirement for generators (#117)

### DIFF
--- a/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObject.java
@@ -253,6 +253,29 @@ public class GeneratorTierObject implements DataObject
 
 
     /**
+     * Method GeneratorTierObject#getRequiredBlockCount returns the number of OneBlock blocks that must be broken on the
+     * island before this generator becomes available.
+     *
+     * @return the requiredBlockCount (type int) of this object, or 0 if none.
+     */
+    public int getRequiredBlockCount()
+    {
+        return requiredBlockCount;
+    }
+
+
+    /**
+     * Method GeneratorTierObject#setRequiredBlockCount sets new value for the requiredBlockCount of this object.
+     *
+     * @param requiredBlockCount new value for this object.
+     */
+    public void setRequiredBlockCount(int requiredBlockCount)
+    {
+        this.requiredBlockCount = requiredBlockCount;
+    }
+
+
+    /**
      * Method GeneratorTierObject#getGeneratorTierCost returns the generatorTierCost of this object.
      *
      * @return the generatorTierCost (type double) of this object.
@@ -596,6 +619,7 @@ public class GeneratorTierObject implements DataObject
         clone.setRequiredPermissions(new HashSet<>(this.requiredPermissions));
         clone.setRequiredGeneratorTiers(new HashSet<>(this.getRequiredGeneratorTiers()));
         clone.setRequiredPhase(this.requiredPhase);
+        clone.setRequiredBlockCount(this.requiredBlockCount);
         clone.setGeneratorTierCost(this.generatorTierCost);
         clone.setActivationCost(this.activationCost);
         clone.setDeployed(this.deployed);
@@ -754,6 +778,13 @@ public class GeneratorTierObject implements DataObject
      */
     @Expose
     private String requiredPhase = "";
+
+    /**
+     * Number of OneBlock blocks that must be broken on the island before this generator becomes available. 0 means no
+     * block count requirement.
+     */
+    @Expose
+    private int requiredBlockCount = 0;
 
     /**
      * Cost to do buy current generator.

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManager.java
@@ -881,6 +881,9 @@ public class StoneGeneratorManager {
 		// Filter out generators whose required AOneBlock phase has not been reached yet (#121).
 		filter(generator -> this.isPhaseRequirementMet(island, generator))
 		.
+		// Filter out generators whose required OneBlock block count has not been reached yet (#117).
+		filter(generator -> this.isBlockCountRequirementMet(island, generator))
+		.
 		// Now process each generator.
 		forEach(generator -> this.unlockGenerator(dataObject, user, island, generator));
 
@@ -1527,17 +1530,54 @@ public class StoneGeneratorManager {
 	    return true;
 	}
 
-	Optional<GameModeAddon> gameMode = this.addon.getPlugin().getIWM().getAddon(island.getWorld());
+	Optional<AOneBlock> aoneBlock = this.getAOneBlock(island.getWorld());
 
-	if (gameMode.isEmpty() || !(gameMode.get() instanceof AOneBlock aoneBlock)) {
+	if (aoneBlock.isEmpty()) {
 	    // Phase requirements only apply to AOneBlock worlds.
 	    return false;
 	}
 
+	AOneBlock addon = aoneBlock.get();
+
 	// The requirement is met once the island's block count has reached the required phase's starting block.
-	return aoneBlock.getOneBlockManager().getPhase(requiredPhase)
-		.map(phase -> aoneBlock.getOneBlocksIsland(island).getBlockNumber() >= phase.getBlockNumberValue())
+	return addon.getOneBlockManager().getPhase(requiredPhase)
+		.map(phase -> addon.getOneBlocksIsland(island).getBlockNumber() >= phase.getBlockNumberValue())
 		.orElse(false);
+    }
+
+    /**
+     * This method returns whether the given generator's OneBlock block count requirement is met for the given island. A
+     * generator with no required block count is always considered met. Otherwise the island's world must be an AOneBlock
+     * world and the island must have broken at least the required number of blocks (#117).
+     *
+     * @param island    the island.
+     * @param generator the generator tier to check.
+     * @return {@code true} if the block count requirement is met.
+     */
+    private boolean isBlockCountRequirementMet(@NotNull Island island, @NotNull GeneratorTierObject generator) {
+	final int requiredBlockCount = generator.getRequiredBlockCount();
+
+	if (requiredBlockCount <= 0) {
+	    // No block count requirement.
+	    return true;
+	}
+
+	// Block count requirements only apply to AOneBlock worlds.
+	return this.getAOneBlock(island.getWorld())
+		.map(addon -> addon.getOneBlocksIsland(island).getBlockNumber() >= requiredBlockCount)
+		.orElse(false);
+    }
+
+    /**
+     * This method returns the AOneBlock addon that manages the given world, if that world is an AOneBlock world.
+     *
+     * @param world the world to check.
+     * @return an optional AOneBlock addon.
+     */
+    private Optional<AOneBlock> getAOneBlock(World world) {
+	return this.addon.getPlugin().getIWM().getAddon(world)
+		.filter(AOneBlock.class::isInstance)
+		.map(AOneBlock.class::cast);
     }
 
     /**

--- a/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
+++ b/src/main/java/world/bentobox/magiccobblestonegenerator/panels/CommonPanel.java
@@ -547,6 +547,18 @@ public abstract class CommonPanel
             phase = "";
         }
 
+        String blockCount;
+
+        if (generator.getRequiredBlockCount() > 0 && !isUnlocked)
+        {
+            blockCount = this.user.getTranslationOrNothing(reference + "block-count",
+                Constants.NUMBER, String.valueOf(generator.getRequiredBlockCount()));
+        }
+        else
+        {
+            blockCount = "";
+        }
+
         StringBuilder permissions = new StringBuilder();
 
         if (!generator.getRequiredPermissions().isEmpty() && !isUnlocked)
@@ -615,6 +627,7 @@ public abstract class CommonPanel
             "[biomes]", biomes.toString(),
             "[level]", level,
             "[phase]", phase,
+            "[block-count]", blockCount,
             "[missing-permissions]", permissions.toString(),
             "[required-generators]", requiredGenerators.toString());
     }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -922,12 +922,15 @@ stone-generator:
             [biomes]
             [level]
             [phase]
+            [block-count]
             [required-generators]
             [missing-permissions]
           # Generates [level] message.
           level: "<red><bold>Required Level: </bold></red><red>[number]</red>"
           # Generates [phase] message (AOneBlock only).
           phase: "<red><bold>Required Phase: </bold></red><red>[name]</red>"
+          # Generates [block-count] message (AOneBlock only).
+          block-count: "<red><bold>Required Blocks Broken: </bold></red><red>[number]</red>"
           # Generates [required-generators] message title.
           required-generators-title: "<red><bold>Required Generators:</bold></red>"
           # Generates [required-generators] message values.

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/database/objects/GeneratorTierObjectTest.java
@@ -46,6 +46,27 @@ class GeneratorTierObjectTest extends CommonTestSetup {
     }
 
     @Test
+    void testRequiredBlockCountDefaultsToZero() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        assertEquals(0, tier.getRequiredBlockCount());
+    }
+
+    @Test
+    void testSetAndGetRequiredBlockCount() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setRequiredBlockCount(5000);
+        assertEquals(5000, tier.getRequiredBlockCount());
+    }
+
+    @Test
+    void testCloneCopiesRequiredBlockCount() {
+        GeneratorTierObject tier = new GeneratorTierObject();
+        tier.setUniqueId("tier");
+        tier.setRequiredBlockCount(5000);
+        assertEquals(5000, tier.clone().getRequiredBlockCount());
+    }
+
+    @Test
     void testRequiredGeneratorTiersDefaultsToEmpty() {
         GeneratorTierObject tier = new GeneratorTierObject();
         assertTrue(tier.getRequiredGeneratorTiers().isEmpty());

--- a/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
+++ b/src/test/java/world/bentobox/magiccobblestonegenerator/managers/StoneGeneratorManagerTest.java
@@ -572,6 +572,54 @@ class StoneGeneratorManagerTest extends CommonTestSetup {
         assertFalse(data.getUnlockedTiers().contains("magiccobblegenerator_phasegen"));
     }
 
+    /**
+     * Sets up an AOneBlock world whose island has broken the given number of blocks, plus a generator that requires the
+     * given block count. Returns the island's data object (#117).
+     */
+    private GeneratorDataObject seedBlockCountGenerator(int islandBlockCount, int requiredBlockCount) {
+        sgm.addWorld(world);
+        when(island.getUniqueId()).thenReturn("island-117");
+        when(island.getWorld()).thenReturn(world);
+        when(island.isSpawn()).thenReturn(false);
+        s.setNotifyUnlockedGenerators(false);
+
+        AOneBlock aoneBlock = mock(AOneBlock.class);
+        when(aoneBlock.getDescription()).thenReturn(
+                new AddonDescription.Builder("", "AOneBlock", "1.0").build());
+        OneBlockIslands obIsland = mock(OneBlockIslands.class);
+        when(obIsland.getBlockNumber()).thenReturn(islandBlockCount);
+        when(aoneBlock.getOneBlocksIsland(island)).thenReturn(obIsland);
+        when(iwm.getAddon(world)).thenReturn(Optional.of(aoneBlock));
+
+        GeneratorTierObject tier = prerequisiteTier("aoneblock_blockgen", "Block Gen", 10);
+        when(tier.getRequiredBlockCount()).thenReturn(requiredBlockCount);
+        sgm.loadGeneratorTier(tier, true, null);
+
+        GeneratorDataObject data = sgm.getGeneratorData(island);
+        assertNotNull(data);
+        return data;
+    }
+
+    @Test
+    void testUnlocksBlockCountGeneratorWhenReached() {
+        // Island has broken 1500 blocks, past the required 1000.
+        GeneratorDataObject data = seedBlockCountGenerator(1500, 1000);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertTrue(data.getUnlockedTiers().contains("aoneblock_blockgen"));
+    }
+
+    @Test
+    void testKeepsBlockCountGeneratorLockedWhenNotReached() {
+        // Island has broken only 500 blocks, short of the required 1000.
+        GeneratorDataObject data = seedBlockCountGenerator(500, 1000);
+
+        sgm.checkGeneratorUnlockStatus(island, null, null);
+
+        assertFalse(data.getUnlockedTiers().contains("aoneblock_blockgen"));
+    }
+
     @Test
     void testGetGeneratorDataIsland() {
         assertNotNull(sgm.getGeneratorData(island));


### PR DESCRIPTION
Closes #117

## Feature
Completes the OneBlock progression-unlocking from #117. The issue proposed two ways to gate a generator on OneBlock progress: by **phase** (handled by #121) and by **blocks broken** (`blocks: 5000`, this PR). This gives servers a **level-free** way to unlock generators as players dig through their one-block — the requester's stated goal.

## Change
- **Data model:** `GeneratorTierObject.requiredBlockCount` (int, `@Expose`, cloned, `0` = none).
- **Enforcement:** `checkGeneratorUnlockStatus` gains a block-count filter — a generator unlocks once the island's OneBlock block count (`getOneBlocksIsland(island).getBlockNumber()`, same value as `/ob count`) reaches the requirement. Non-AOneBlock worlds never satisfy it. Shares a `getAOneBlock(world)` helper with the #121 phase check.
- **Display:** requirements lore shows a `Required Blocks Broken` line (`[block-count]`) with new en-US locale strings.

## Tests
- `GeneratorTierObjectTest`: `requiredBlockCount` default/set/get/clone.
- `StoneGeneratorManagerTest` (mocking AOneBlock): unlocks when reached; stays locked when not.

Full suite: 118 tests pass.

## ⚠️ Stacked on #121
This branch is **based on `121-oneblock-phase-requirement`** (it reuses that PR's AOneBlock dependency + integration). Since GitHub wouldn't let me target the branch directly, this PR is opened against `develop`, so **its diff currently also shows #121's commits**. Please **merge #121 first**; once it lands, this PR's diff collapses to just the block-count delta. Reviewing the two together is fine too.

`requiredBlockCount` is configurable via generator export/import JSON for now; a GUI editor is a follow-up (the edit panel is full).

🤖 Generated with [Claude Code](https://claude.com/claude-code)