### PR TITLE
Release 2.10.0 — add platform publish workflows

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: 21
           distribution: adopt
@@ -23,7 +23,7 @@ jobs:
         run: mvn -B clean package -DskipTests -DgenerateBackupPoms=false -Pmaster --file pom.xml
 
       - name: Upload to Modrinth
-        uses: cloudnode-pro/modrinth-publish@v2
+        uses: cloudnode-pro/modrinth-publish@0be4916ad5f081d936eb5615aa35ce3f0949979c # v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: NnkaZPqQ

--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: adopt
+          cache: maven
+
+      - name: Build and package with Maven
+        run: mvn -B clean package -DskipTests -DgenerateBackupPoms=false -Pmaster --file pom.xml
+
+      - name: Upload to Modrinth
+        uses: cloudnode-pro/modrinth-publish@v2
+        with:
+          token: ${{ secrets.MODRINTH_TOKEN }}
+          project: NnkaZPqQ
+          name: ${{ github.event.release.name }}
+          version: ${{ github.event.release.tag_name }}
+          changelog: ${{ github.event.release.body }}
+          loaders: |-
+            paper
+            spigot
+          game-versions: |-
+            1.21.5
+            1.21.6
+            1.21.7
+            1.21.8
+            1.21.9
+            1.21.10
+            1.21.11
+            26.1
+            26.1.1
+            26.1.2
+            26.2
+          files: ${{ github.workspace }}/target/MagicCobblestoneGenerator-${{ github.event.release.tag_name }}.jar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: ""                    # blank = skip Hangar (not published there)
+      hangar_slug: "MagicCobblestoneGenerator"   # blank = skip Hangar
       curseforge_id: "1606770"
       game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+# MagicCobblestoneGenerator — .github/workflows/publish.yml
+# Publishes the jar attached to a GitHub release to CurseForge and Hangar via the
+# shared BentoBoxWorld/.github reusable workflow. Downloads the release asset instead of
+# rebuilding from source. The reusable workflow is pinned to a commit SHA (Sonar
+# githubactions:S7637). workflow_dispatch lets you (re)publish a given version.
+
+name: Publish release to CurseForge and Hangar
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
+    with:
+      use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
+      hangar_slug: ""                    # blank = skip Hangar (not published there)
+      curseforge_id: "1606770"
+      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
+    secrets:
+      HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
## Summary

Re-syncs `develop` → `master` to bring across the platform publish workflows added in #167 (the 2.10.0 addon changes already reached master via #166).

Adds two `release: published` workflows so publishing the 2.10.0 GitHub release pushes the jar to all three platforms:

- **`modrinth-publish.yml`** — Modrinth (project `NnkaZPqQ`)
- **`publish.yml`** — CurseForge (`1606770`) + Hangar (`MagicCobblestoneGenerator`) via the shared `BentoBoxWorld/.github` reusable workflow

All actions are pinned to full-length commit SHAs (Sonar `githubactions:S7637`). Platform secrets are provided at the org level.

> Note: release-triggered workflows run from the **default branch** (`develop`), where #167 is already merged — so publishing will fire the pushes regardless. This PR keeps `master` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)