### PR TITLE
Require BentoBox 3.19.1 at runtime

### DIFF
--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -1,7 +1,7 @@
 name: MagicCobblestoneGenerator
 main: world.bentobox.magiccobblestonegenerator.StoneGeneratorAddon
 version: ${version}${build.number}
-api-version: ${bentobox.version}
+api-version: 3.19.1
 repository: 'BentoBoxWorld/MagicCobblestoneGenerator'
 metrics: true
 icon: COBBLESTONE


### PR DESCRIPTION
## Summary

The 2.10.0 custom block support relies on BentoBox hook functionality that is only present in **BentoBox 3.19.1+**. On an older core those calls fail. This sets the addon's minimum `api-version` to `3.19.1` so BentoBox refuses to load the addon on an older core rather than failing at runtime.

## Why hardcoded, not `${bentobox.version}`

`addon.yml` previously filtered `api-version` from the pom's `${bentobox.version}` (3.17.0), which is also the **compile** dependency. Bumping that property to 3.19.1 would break the build — 3.18.x+ artifacts are compiled for Java 25 and can't be read by the Java 21 CI toolchain.

Hardcoding `api-version: 3.19.1` (as every other BentoBox addon does) decouples the **runtime minimum** (3.19.1) from the **compile dependency** (3.17.0), so CI keeps building on Java 21 while servers are correctly required to run BentoBox 3.19.1+.

> 🔺 Admins must be on BentoBox 3.19.1+ to use 2.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)